### PR TITLE
Display error if encoding of response fails

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package brokerapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/pivotal-cf/brokerapi/auth"
@@ -219,5 +220,9 @@ func respond(w http.ResponseWriter, status int, response interface{}) {
 	w.WriteHeader(status)
 
 	encoder := json.NewEncoder(w)
-	encoder.Encode(response)
+	err := encoder.Encode(response)
+	if err != nil {
+		fmt.Printf("failed response (%d) encoding of %#v\n", status, response)
+		fmt.Println(err)
+	}
 }


### PR DESCRIPTION
e.g. if response is `map[interface{}]interface{}` then encoding fails