### PR TITLE
unbind/deprovision parses incoming service_id/plan_id parameters

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package brokerapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/pivotal-cf/brokerapi/auth"
@@ -19,6 +20,8 @@ const bindingIDLogKey = "binding-id"
 
 const invalidServiceDetailsErrorKey = "invalid-service-details"
 const invalidBindDetailsErrorKey = "invalid-bind-details"
+const invalidUnbindDetailsErrorKey = "invalid-unbind-details"
+const invalidDeprovisionDetailsErrorKey = "invalid-deprovision-details"
 const instanceLimitReachedErrorKey = "instance-limit-reached"
 const instanceAlreadyExistsErrorKey = "instance-already-exists"
 const bindingAlreadyExistsErrorKey = "binding-already-exists"
@@ -114,7 +117,12 @@ func deprovision(serviceBroker ServiceBroker, router httpRouter, logger lager.Lo
 			instanceIDLogKey: instanceID,
 		})
 
-		if err := serviceBroker.Deprovision(instanceID); err != nil {
+		details := DeprovisionDetails{
+			PlanID:    req.FormValue("plan_id"),
+			ServiceID: req.FormValue("service_id"),
+		}
+
+		if err := serviceBroker.Deprovision(instanceID, details); err != nil {
 			switch err {
 			case ErrInstanceDoesNotExist:
 				logger.Error(instanceMissingErrorKey, err)
@@ -193,7 +201,12 @@ func unbind(serviceBroker ServiceBroker, router httpRouter, logger lager.Logger)
 			bindingIDLogKey:  bindingID,
 		})
 
-		if err := serviceBroker.Unbind(instanceID, bindingID); err != nil {
+		details := UnbindDetails{
+			PlanID:    req.FormValue("plan_id"),
+			ServiceID: req.FormValue("service_id"),
+		}
+
+		if err := serviceBroker.Unbind(instanceID, bindingID, details); err != nil {
 			switch err {
 			case ErrInstanceDoesNotExist:
 				logger.Error(instanceMissingErrorKey, err)
@@ -219,5 +232,9 @@ func respond(w http.ResponseWriter, status int, response interface{}) {
 	w.WriteHeader(status)
 
 	encoder := json.NewEncoder(w)
-	encoder.Encode(response)
+	err := encoder.Encode(response)
+	if err != nil {
+		fmt.Printf("response being attempted %d %#v\n", status, response)
+		fmt.Println(err)
+	}
 }

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -3,7 +3,8 @@ package fakes
 import "github.com/pivotal-cf/brokerapi"
 
 type FakeServiceBroker struct {
-	ProvisionDetails brokerapi.ProvisionDetails
+	ProvisionDetails   brokerapi.ProvisionDetails
+	DeprovisionDetails brokerapi.DeprovisionDetails
 
 	ProvisionedInstanceIDs   []string
 	DeprovisionedInstanceIDs []string
@@ -11,6 +12,8 @@ type FakeServiceBroker struct {
 	BoundInstanceIDs    []string
 	BoundBindingIDs     []string
 	BoundBindingDetails brokerapi.BindDetails
+
+	UnbindingDetails brokerapi.UnbindDetails
 
 	InstanceLimit int
 
@@ -82,13 +85,14 @@ func (fakeBroker *FakeServiceBroker) Provision(instanceID string, details broker
 	return nil
 }
 
-func (fakeBroker *FakeServiceBroker) Deprovision(instanceID string) error {
+func (fakeBroker *FakeServiceBroker) Deprovision(instanceID string, details brokerapi.DeprovisionDetails) error {
 	fakeBroker.BrokerCalled = true
 
 	if fakeBroker.DeprovisionError != nil {
 		return fakeBroker.DeprovisionError
 	}
 
+	fakeBroker.DeprovisionDetails = details
 	fakeBroker.DeprovisionedInstanceIDs = append(fakeBroker.DeprovisionedInstanceIDs, instanceID)
 
 	if sliceContains(instanceID, fakeBroker.ProvisionedInstanceIDs) {
@@ -117,8 +121,10 @@ func (fakeBroker *FakeServiceBroker) Bind(instanceID, bindingID string, details 
 	}, nil
 }
 
-func (fakeBroker *FakeServiceBroker) Unbind(instanceID, bindingID string) error {
+func (fakeBroker *FakeServiceBroker) Unbind(instanceID, bindingID string, details brokerapi.UnbindDetails) error {
 	fakeBroker.BrokerCalled = true
+
+	fakeBroker.UnbindingDetails = details
 
 	if sliceContains(instanceID, fakeBroker.ProvisionedInstanceIDs) {
 		if sliceContains(bindingID, fakeBroker.BoundBindingIDs) {

--- a/service_broker.go
+++ b/service_broker.go
@@ -6,10 +6,10 @@ type ServiceBroker interface {
 	Services() []Service
 
 	Provision(instanceID string, details ProvisionDetails) error
-	Deprovision(instanceID string) error
+	Deprovision(instanceID string, details DeprovisionDetails) error
 
 	Bind(instanceID, bindingID string, details BindDetails) (interface{}, error)
-	Unbind(instanceID, bindingID string) error
+	Unbind(instanceID, bindingID string, details UnbindDetails) error
 }
 
 type ProvisionDetails struct {
@@ -17,14 +17,24 @@ type ProvisionDetails struct {
 	PlanID           string                 `json:"plan_id"`
 	OrganizationGUID string                 `json:"organization_guid"`
 	SpaceGUID        string                 `json:"space_guid"`
-	Parameters       map[string]interface{} `json:"parameters"`
+	Parameters       map[string]interface{} `json:"parameters,omitempty"`
 }
 
 type BindDetails struct {
 	AppGUID    string                 `json:"app_guid"`
 	PlanID     string                 `json:"plan_id"`
 	ServiceID  string                 `json:"service_id"`
-	Parameters map[string]interface{} `json:"parameters"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+type UnbindDetails struct {
+	PlanID    string `json:"plan_id"`
+	ServiceID string `json:"service_id"`
+}
+
+type DeprovisionDetails struct {
+	PlanID    string `json:"plan_id"`
+	ServiceID string `json:"service_id"`
 }
 
 var (


### PR DESCRIPTION
The Services API has mandatory parameters for unbind/deprovision - this PR parses them and passes them into `Unbind` and `Deprovision`. Therefore it does extend the function signature for these two methods.