### PR TITLE
Expose the raw JSON parameters of a provisioning request

### DIFF
--- a/api.go
+++ b/api.go
@@ -89,6 +89,16 @@ func (h serviceBrokerHandler) provision(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	if details.RawParameters != nil {
+		if err := json.Unmarshal(details.RawParameters, &details.Parameters); err != nil {
+			logger.Error(invalidServiceDetailsErrorKey, err)
+			h.respond(w, statusUnprocessableEntity, ErrorResponse{
+				Description: err.Error(),
+			})
+			return
+		}
+	}
+
 	acceptsIncompleteFlag, _ := strconv.ParseBool(req.URL.Query().Get("accepts_incomplete"))
 
 	logger = logger.WithData(lager.Data{

--- a/service_broker.go
+++ b/service_broker.go
@@ -1,6 +1,9 @@
 package brokerapi
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+)
 
 type ServiceBroker interface {
 	Services() []Service
@@ -19,11 +22,12 @@ type ServiceBroker interface {
 type IsAsync bool
 
 type ProvisionDetails struct {
-	ServiceID        string                 `json:"service_id"`
-	PlanID           string                 `json:"plan_id"`
-	OrganizationGUID string                 `json:"organization_guid"`
-	SpaceGUID        string                 `json:"space_guid"`
-	Parameters       map[string]interface{} `json:"parameters,omitempty"`
+	ServiceID        string          `json:"service_id"`
+	PlanID           string          `json:"plan_id"`
+	OrganizationGUID string          `json:"organization_guid"`
+	SpaceGUID        string          `json:"space_guid"`
+	RawParameters    json.RawMessage `json:"parameters,omitempty"`
+	Parameters       map[string]interface{}
 }
 
 type ProvisionedServiceSpec struct {


### PR DESCRIPTION
This allows consumers to decode the params to their own custom structs