### PR TITLE
add volume mounts as per 2.9 service broker api spec

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -939,6 +939,25 @@ var _ = Describe("Service Broker API", func() {
 					})
 				})
 
+				Context("when a volume mount is being passed", func() {
+					BeforeEach(func() {
+						fakeServiceBroker.VolumeMounts = []brokerapi.VolumeMount{{
+							ContainerPath: "/dev/null",
+							Mode:          "rw",
+							Private: brokerapi.VolumeMountPrivate{
+								Driver:  "driver",
+								GroupId: "some-guid",
+								Config:  "config",
+							},
+						}}
+					})
+
+					It("responds with a volume mount", func() {
+						response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
+						Expect(response.Body).To(MatchJSON(fixture("binding_with_volume_mounts.json")))
+					})
+				})
+
 				Context("when no bind details are being passed", func() {
 					It("returns a 422", func() {
 						response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), nil)

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -16,6 +16,7 @@ type FakeServiceBroker struct {
 	BoundBindingDetails brokerapi.BindDetails
 	SyslogDrainURL      string
 	RouteServiceURL     string
+	VolumeMounts        []brokerapi.VolumeMount
 
 	UnbindingDetails brokerapi.UnbindDetails
 
@@ -237,6 +238,7 @@ func (fakeBroker *FakeServiceBroker) Bind(instanceID, bindingID string, details 
 		},
 		SyslogDrainURL:  fakeBroker.SyslogDrainURL,
 		RouteServiceURL: fakeBroker.RouteServiceURL,
+		VolumeMounts:    fakeBroker.VolumeMounts,
 	}, nil
 }
 

--- a/fixtures/binding_with_volume_mounts.json
+++ b/fixtures/binding_with_volume_mounts.json
@@ -1,0 +1,17 @@
+{
+  "credentials": {
+    "host": "127.0.0.1",
+    "port": 3000,
+    "username": "batman",
+    "password": "robin"
+  },
+	"volume_mounts": [{
+		"container_path": "/dev/null",
+		"mode": "rw",
+		"private": {
+			"driver": "driver",
+			"group_id": "some-guid",
+			"config": "config"
+		}
+	}]
+}

--- a/service_broker.go
+++ b/service_broker.go
@@ -94,9 +94,22 @@ const (
 )
 
 type Binding struct {
-	Credentials     interface{} `json:"credentials"`
-	SyslogDrainURL  string      `json:"syslog_drain_url,omitempty"`
-	RouteServiceURL string      `json:"route_service_url,omitempty"`
+	Credentials     interface{}   `json:"credentials"`
+	SyslogDrainURL  string        `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string        `json:"route_service_url,omitempty"`
+	VolumeMounts    []VolumeMount `json:"volume_mounts,omitempty"`
+}
+
+type VolumeMount struct {
+	ContainerPath string             `json:"container_path"`
+	Mode          string             `json:"mode"`
+	Private       VolumeMountPrivate `json:"private"`
+}
+
+type VolumeMountPrivate struct {
+	Driver  string `json:"driver"`
+	GroupId string `json:"group_id"`
+	Config  string `json:"config"`
 }
 
 var (


### PR DESCRIPTION
see: http://docs.cloudfoundry.org/services/api.html#binding and http://docs.cloudfoundry.org/services/api.html#binding

this api isn't stable yet, so there will be another one of these PRs, but we're pointing at this fork for now and would love to be back on master :)