### PR TITLE
Volume Mounts backwards compatibility support

### DIFF
--- a/fixtures/2.9binding_with_volume_mounts.json
+++ b/fixtures/2.9binding_with_volume_mounts.json
@@ -1,0 +1,19 @@
+{
+  "credentials": {
+    "host": "127.0.0.1",
+    "port": 3000,
+    "username": "batman",
+    "password": "robin"
+  },
+  "volume_mounts": [
+    {
+      "container_path": "/dev/null",
+      "mode": "rw",
+      "private": {
+        "driver": "driver",
+        "group_id": "some-guid",
+        "config": "{\"key\":\"value\"}"
+      }
+    }
+  ]
+}

--- a/service_broker.go
+++ b/service_broker.go
@@ -113,6 +113,25 @@ type SharedDevice struct {
 	MountConfig map[string]interface{} `json:"mount_config"`
 }
 
+type V2_9Binding struct {
+	Credentials     interface{}   `json:"credentials"`
+	SyslogDrainURL  string        `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string        `json:"route_service_url,omitempty"`
+	VolumeMounts    []V2_9VolumeMount `json:"volume_mounts,omitempty"`
+}
+
+type V2_9VolumeMount struct {
+	ContainerPath string             `json:"container_path"`
+	Mode          string             `json:"mode"`
+	Private       V2_9VolumeMountPrivate `json:"private"`
+}
+
+type V2_9VolumeMountPrivate struct {
+	Driver  string `json:"driver"`
+	GroupId string `json:"group_id"`
+	Config  string `json:"config"`
+}
+
 var (
 	ErrInstanceAlreadyExists  = errors.New("instance already exists")
 	ErrInstanceDoesNotExist   = errors.New("instance does not exist")


### PR DESCRIPTION
Enables v2.10 capable volume service brokers to also interact with v2.8 and v2.9 CF versions.

[#130410789](https://www.pivotaltracker.com/story/show/130410789)

Signed-off-by: Julian Hjortshoj <julian.hjortshoj@emc.com>