### PR TITLE
Drop redundant error type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,13 @@ The error types are:
 ErrInstanceAlreadyExists
 ErrInstanceDoesNotExist
 ErrInstanceLimitMet
+ErrPlanQuotaExceeded
 ErrBindingAlreadyExists
 ErrBindingDoesNotExist
 ErrAsyncRequired
+ErrPlanChangeNotSupported
+ErrRawParamsInvalid
+ErrAppGuidNotProvided
 ```
 
 ## Change Notes


### PR DESCRIPTION
Edited:

Since Cloud Controller checks whether service plans can be updated
before calling the service broker, the `ErrPlanChangeNotSupported` error
is redundant.

* Drop `ErrPlanChangeNotSupported` error
* Add missing errors to docs