### PR TITLE
Support experimental volume mount binding response API

### DIFF
--- a/api.go
+++ b/api.go
@@ -278,7 +278,8 @@ func (h serviceBrokerHandler) bind(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.Header.Get("X-Broker-Api-Version") == "2.9" {
+	brokerAPIVersion := req.Header.Get("X-Broker-Api-Version")
+	if brokerAPIVersion == "2.8" || brokerAPIVersion == "2.9" {
 		experimentalVols := []ExperimentalVolumeMount{}
 
 		for _, vol := range binding.VolumeMounts {

--- a/api_test.go
+++ b/api_test.go
@@ -971,6 +971,13 @@ var _ = Describe("Service Broker API", func() {
 							Expect(response.Body).To(MatchJSON(fixture("binding_with_experimental_volume_mounts.json")))
 						})
 					})
+
+					Context("when the broker API version is 2.8", func() {
+						It("responds with an experimental volume mount", func() {
+							response := makeBindingRequestWithSpecificAPIVersion(uniqueInstanceID(), uniqueBindingID(), details, "2.8")
+							Expect(response.Body).To(MatchJSON(fixture("binding_with_experimental_volume_mounts.json")))
+						})
+					})
 				})
 
 				Context("when no bind details are being passed", func() {

--- a/fixtures/binding_with_experimental_volume_mounts.json
+++ b/fixtures/binding_with_experimental_volume_mounts.json
@@ -1,0 +1,17 @@
+{
+    "credentials": {
+        "host": "127.0.0.1",
+        "port": 3000,
+        "username": "batman",
+        "password": "robin"
+    },
+    "volume_mounts": [{
+        "container_path": "/dev/null",
+        "mode": "rw",
+        "private": {
+            "driver": "driver",
+            "group_id": "some-guid",
+            "config": "{\"key\":\"value\"}"
+        }
+    }]
+}

--- a/response.go
+++ b/response.go
@@ -28,3 +28,22 @@ type LastOperationResponse struct {
 	State       string `json:"state"`
 	Description string `json:"description,omitempty"`
 }
+
+type ExperimentalVolumeMountBindingResponse struct {
+	Credentials     interface{}               `json:"credentials"`
+	SyslogDrainURL  string                    `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string                    `json:"route_service_url,omitempty"`
+	VolumeMounts    []ExperimentalVolumeMount `json:"volume_mounts,omitempty"`
+}
+
+type ExperimentalVolumeMount struct {
+	ContainerPath string                         `json:"container_path"`
+	Mode          string                         `json:"mode"`
+	Private       ExperimentalVolumeMountPrivate `json:"private"`
+}
+
+type ExperimentalVolumeMountPrivate struct {
+	Driver  string `json:"driver"`
+	GroupID string `json:"group_id"`
+	Config  string `json:"config"`
+}


### PR DESCRIPTION
When the broker API version header is 2.9, we transform the broker's 2.10-style binding response into a 2.9 experimental one when volume mounts are present.

Notes

1. We map `volume_id` onto `group_id`, as the UUIDs are identical in the API docs, although this probably coincidence!
1. We JSON-marshal the `mount_config` object returned by the broker. We weren't sure what encoding to use to squash this into a string, but JSON seemed reasonable.

What do you think @avade and @lwoydziak ?

Cheers,
@ablease and Craig