### PR TITLE
Some cleanup

### DIFF
--- a/api.go
+++ b/api.go
@@ -382,7 +382,7 @@ func (h serviceBrokerHandler) lastOperation(w http.ResponseWriter, req *http.Req
 	logger.WithData(lager.Data{"state": lastOperation.State}).Info("done-check-for-operation")
 
 	lastOperationResponse := LastOperationResponse{
-		State:       string(lastOperation.State),
+		State:       lastOperation.State,
 		Description: lastOperation.Description,
 	}
 

--- a/response.go
+++ b/response.go
@@ -25,8 +25,8 @@ type DeprovisionResponse struct {
 }
 
 type LastOperationResponse struct {
-	State       string `json:"state"`
-	Description string `json:"description,omitempty"`
+	State       LastOperationState `json:"state"`
+	Description string             `json:"description,omitempty"`
 }
 
 type ExperimentalVolumeMountBindingResponse struct {

--- a/service_broker.go
+++ b/service_broker.go
@@ -1,9 +1,9 @@
 package brokerapi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
-	"context"
 )
 
 type ServiceBroker interface {
@@ -68,10 +68,10 @@ type DeprovisionDetails struct {
 }
 
 type UpdateDetails struct {
-	ServiceID      string                 `json:"service_id"`
-	PlanID         string                 `json:"plan_id"`
-	Parameters     map[string]interface{} `json:"parameters"`
-	PreviousValues PreviousValues         `json:"previous_values"`
+	ServiceID      string          `json:"service_id"`
+	PlanID         string          `json:"plan_id"`
+	RawParameters  json.RawMessage `json:"parameters,omitempty"`
+	PreviousValues PreviousValues  `json:"previous_values"`
 }
 
 type PreviousValues struct {

--- a/service_broker.go
+++ b/service_broker.go
@@ -126,4 +126,5 @@ var (
 	ErrRawParamsInvalid       = errors.New("The format of the parameters is not valid JSON")
 	ErrAppGuidNotProvided     = errors.New("app_guid is a required field but was not provided")
 	ErrInstanceNotUpdateable  = errors.New("instance is not updateable")
+	ErrInstanceNotBindable    = errors.New("instance is not bindable")
 )

--- a/service_broker.go
+++ b/service_broker.go
@@ -35,11 +35,11 @@ type ProvisionedServiceSpec struct {
 }
 
 type BindDetails struct {
-	AppGUID      string                 `json:"app_guid"`
-	PlanID       string                 `json:"plan_id"`
-	ServiceID    string                 `json:"service_id"`
-	BindResource *BindResource          `json:"bind_resource,omitempty"`
-	Parameters   map[string]interface{} `json:"parameters,omitempty"`
+	AppGUID       string          `json:"app_guid"`
+	PlanID        string          `json:"plan_id"`
+	ServiceID     string          `json:"service_id"`
+	BindResource  *BindResource   `json:"bind_resource,omitempty"`
+	RawParameters json.RawMessage `json:"parameters,omitempty"`
 }
 
 type BindResource struct {

--- a/service_broker.go
+++ b/service_broker.go
@@ -125,4 +125,5 @@ var (
 	ErrPlanChangeNotSupported = errors.New("The requested plan migration cannot be performed")
 	ErrRawParamsInvalid       = errors.New("The format of the parameters is not valid JSON")
 	ErrAppGuidNotProvided     = errors.New("app_guid is a required field but was not provided")
+	ErrInstanceNotUpdateable  = errors.New("instance is not updateable")
 )


### PR DESCRIPTION
Hi,
I really like the broker API. During my work I found some small things you might like to merge.

1. The RawParameters are sometimes of type``` json.RawMessage``` and sometimes of type ```map[string]interface{}```. I changed them all to ```json.RawMessge```
2. I added two default Errors I frequently need. Would like to know what you thing about my suggestions
3. Changed state type from string to LastOperationState

Cheers
joek