### PR TITLE
LastOperation should return 410 when the instance doesn't exist

### DIFF
--- a/api.go
+++ b/api.go
@@ -366,7 +366,7 @@ func (h serviceBrokerHandler) lastOperation(w http.ResponseWriter, req *http.Req
 		switch err {
 		case ErrInstanceDoesNotExist:
 			logger.Error(instanceMissingErrorKey, err)
-			h.respond(w, http.StatusNotFound, ErrorResponse{
+			h.respond(w, http.StatusGone, ErrorResponse{
 				Description: err.Error(),
 			})
 		default:

--- a/api_test.go
+++ b/api_test.go
@@ -1333,7 +1333,7 @@ var _ = Describe("Service Broker API", func() {
 				Expect(lastLogLine().Message).To(ContainSubstring("lastOperation.instance-missing"))
 				Expect(lastLogLine().Data["error"]).To(ContainSubstring("instance does not exist"))
 
-				Expect(response.StatusCode).To(Equal(404))
+				Expect(response.StatusCode).To(Equal(410))
 				Expect(response.Body).To(MatchJSON(`{"description": "instance does not exist"}`))
 			})
 

--- a/api_test.go
+++ b/api_test.go
@@ -1325,7 +1325,7 @@ var _ = Describe("Service Broker API", func() {
 				Expect(response.Body).To(MatchJSON(fixture("last_operation_succeeded.json")))
 			})
 
-			It("should return a 404 and log in case the instance id is not found", func() {
+			It("should return a 410 and log in case the instance id is not found", func() {
 				fakeServiceBroker.LastOperationError = brokerapi.ErrInstanceDoesNotExist
 				instanceID := "non-existing"
 				response := makeLastOperationRequest(instanceID, "")


### PR DESCRIPTION
I have a broker with an asynchronous deprovision and according to [the broker API docs](https://docs.cloudfoundry.org/services/api.html#polling), the broker should return a 410 from `lastOperation` once the instance is gone. I'm returning `brokerapi.ErrInstanceDoesNotExist` in my code but that's being translated into a 404 not a 410. This means cloud foundry never removes the service from its database and it continues to be listed by `cf services`. This change fixes that issue. 

I don't know if there was a particular reason to return 404 before but if there is, just let me know and I'll find another solution to this problem. Also, I couldn't find any docs about contributing to this project so apologies if I'm missing something. Please just let me know if you'd like me to do anything differently.