### PR TITLE
Make the library more compatible with the OpenServiceBroker API specification

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -14,10 +14,10 @@ import (
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/drewolson/testflight"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/pivotal-cf/brokerapi/fakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Service Broker API", func() {
@@ -303,6 +303,7 @@ var _ = Describe("Service Broker API", func() {
 
 			Context("when there are arbitrary params", func() {
 				var rawParams string
+				var rawCtx string
 
 				BeforeEach(func() {
 					provisionDetails["parameters"] = map[string]interface{}{
@@ -317,6 +318,18 @@ var _ = Describe("Service Broker API", func() {
 						"object": { "Name": "some-name" },
 						"array": [ "a", "b", "c" ]
 					}`
+					provisionDetails["context"] = map[string]interface{}{
+						"platform":      "fake-platform",
+						"serial-number": 12648430,
+						"object":        struct{ Name string }{"parameter"},
+						"array":         []interface{}{"1", "2", "3"},
+					}
+					rawCtx = `{
+						"platform":"fake-platform",
+						"serial-number":12648430,
+						"object": {"Name":"parameter"},
+						"array":[ "1", "2", "3" ]
+					}`
 				})
 
 				It("calls Provision on the service broker with all params", func() {
@@ -329,6 +342,13 @@ var _ = Describe("Service Broker API", func() {
 					detailsWithRawParameters := brokerapi.DetailsWithRawParameters(fakeServiceBroker.ProvisionDetails)
 					rawParameters := detailsWithRawParameters.GetRawParameters()
 					Expect(string(rawParameters)).To(MatchJSON(rawParams))
+				})
+
+				It("calls Provision with details with raw context", func() {
+					makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
+					detailsWithRawContext := brokerapi.DetailsWithRawContext(fakeServiceBroker.ProvisionDetails)
+					rawContext := detailsWithRawContext.GetRawContext()
+					Expect(string(rawContext)).To(MatchJSON(rawCtx))
 				})
 			})
 

--- a/catalog.go
+++ b/catalog.go
@@ -26,6 +26,25 @@ type ServicePlan struct {
 	Free        *bool                `json:"free,omitempty"`
 	Bindable    *bool                `json:"bindable,omitempty"`
 	Metadata    *ServicePlanMetadata `json:"metadata,omitempty"`
+	Schemas     *ServiceSchemas      `json:"schemas,omitempty"`
+}
+
+type ServiceSchemas struct {
+	Instance ServiceInstanceSchema `json:"service_instance"`
+	Binding  ServiceBindingSchema  `json:"service_binding,omitempty"`
+}
+
+type ServiceInstanceSchema struct {
+	Create Schema `json:"create"`
+	Update Schema `json:"update"`
+}
+
+type ServiceBindingSchema struct {
+	Create Schema `json:"create"`
+}
+
+type Schema struct {
+	Schema interface{} `json:"parameters"`
 }
 
 type ServicePlanMetadata struct {

--- a/catalog.go
+++ b/catalog.go
@@ -30,21 +30,21 @@ type ServicePlan struct {
 }
 
 type ServiceSchemas struct {
-	Instance ServiceInstanceSchema `json:"service_instance"`
+	Instance ServiceInstanceSchema `json:"service_instance,omitempty"`
 	Binding  ServiceBindingSchema  `json:"service_binding,omitempty"`
 }
 
 type ServiceInstanceSchema struct {
-	Create Schema `json:"create"`
-	Update Schema `json:"update"`
+	Create Schema `json:"create,omitempty"`
+	Update Schema `json:"update,omitempty"`
 }
 
 type ServiceBindingSchema struct {
-	Create Schema `json:"create"`
+	Create Schema `json:"create,omitempty"`
 }
 
 type Schema struct {
-	Schema interface{} `json:"parameters"`
+	Schema interface{} `json:"parameters,omitempty"`
 }
 
 type ServicePlanMetadata struct {

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -81,6 +81,48 @@ func (fakeBroker *FakeServiceBroker) Services(context context.Context) []brokera
 						Bullets:     []string{},
 						DisplayName: "Cassandra",
 					},
+					Schemas: &brokerapi.ServiceSchemas{
+						Instance: brokerapi.ServiceInstanceSchema{
+							Create: brokerapi.Schema{
+								Schema: map[string]interface{}{
+									"$schema": "http://json-schema.org/draft-04/schema#",
+									"type":    "object",
+									"properties": map[string]interface{}{
+										"billing-account": map[string]interface{}{
+											"description": "Billing account number used to charge use of shared fake server.",
+											"type":        "string",
+										},
+									},
+								},
+							},
+							Update: brokerapi.Schema{
+								Schema: map[string]interface{}{
+									"$schema": "http://json-schema.org/draft-04/schema#",
+									"type":    "object",
+									"properties": map[string]interface{}{
+										"billing-account": map[string]interface{}{
+											"description": "Billing account number used to charge use of shared fake server.",
+											"type":        "string",
+										},
+									},
+								},
+							},
+						},
+						Binding: brokerapi.ServiceBindingSchema{
+							Create: brokerapi.Schema{
+								Schema: map[string]interface{}{
+									"$schema": "http://json-schema.org/draft-04/schema#",
+									"type":    "object",
+									"properties": map[string]interface{}{
+										"billing-account": map[string]interface{}{
+											"description": "Billing account number used to charge use of shared fake server.",
+											"type":        "string",
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			Metadata: &brokerapi.ServiceMetadata{

--- a/fixtures/catalog.json
+++ b/fixtures/catalog.json
@@ -11,6 +11,48 @@
       "name": "default",
       "metadata": {
         "displayName": "Cassandra"
+      },
+      "schemas": {
+        "service_instance": {
+          "create": {
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "object",
+              "properties": {
+                "billing-account": {
+                  "description": "Billing account number used to charge use of shared fake server.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "update": {
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "object",
+              "properties": {
+                "billing-account": {
+                  "description": "Billing account number used to charge use of shared fake server.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "service_binding": {
+          "create": {
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "object",
+              "properties": {
+                "billing-account": {
+                  "description": "Billing account number used to charge use of shared fake server.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     }],
     "metadata": {

--- a/service_broker.go
+++ b/service_broker.go
@@ -25,6 +25,10 @@ type DetailsWithRawParameters interface {
 	GetRawParameters() json.RawMessage
 }
 
+func (d ProvisionDetails) GetRawContext() json.RawMessage {
+	return d.RawContext
+}
+
 func (d ProvisionDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
@@ -42,6 +46,7 @@ type ProvisionDetails struct {
 	PlanID           string          `json:"plan_id"`
 	OrganizationGUID string          `json:"organization_guid"`
 	SpaceGUID        string          `json:"space_guid"`
+	RawContext       json.RawMessage `json:"context,omitempty"`
 	RawParameters    json.RawMessage `json:"parameters,omitempty"`
 }
 

--- a/service_broker.go
+++ b/service_broker.go
@@ -33,6 +33,10 @@ func (d ProvisionDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
 
+func (d BindDetails) GetRawContext() json.RawMessage {
+	return d.RawContext
+}
+
 func (d BindDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
@@ -61,6 +65,7 @@ type BindDetails struct {
 	PlanID        string          `json:"plan_id"`
 	ServiceID     string          `json:"service_id"`
 	BindResource  *BindResource   `json:"bind_resource,omitempty"`
+	RawContext    json.RawMessage `json:"context,omitempty"`
 	RawParameters json.RawMessage `json:"parameters,omitempty"`
 }
 

--- a/service_broker.go
+++ b/service_broker.go
@@ -25,6 +25,10 @@ type DetailsWithRawParameters interface {
 	GetRawParameters() json.RawMessage
 }
 
+type DetailsWithRawContext interface {
+	GetRawContext() json.RawMessage
+}
+
 func (d ProvisionDetails) GetRawContext() json.RawMessage {
 	return d.RawContext
 }


### PR DESCRIPTION
This pull request adds two things which were introduced in the [OpenServiceBroker API version 2.13](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md) :
1. Allow access the values provided in the "context" parameter for provision and bind requests
2. Allow specifying the various Schema objects in the service plans returned in the catalog 