### PR TITLE
Be more compliant with the OpenServiceBroker specification

### DIFF
--- a/catalog.go
+++ b/catalog.go
@@ -9,7 +9,7 @@ type Service struct {
 	PlanUpdatable   bool                    `json:"plan_updateable"`
 	Plans           []ServicePlan           `json:"plans"`
 	Requires        []RequiredPermission    `json:"requires,omitempty"`
-	Metadata        *ServiceMetadata        `json:"metadata,omitempty"`
+	Metadata        interface{}             `json:"metadata,omitempty"`
 	DashboardClient *ServiceDashboardClient `json:"dashboard_client,omitempty"`
 }
 
@@ -20,13 +20,13 @@ type ServiceDashboardClient struct {
 }
 
 type ServicePlan struct {
-	ID          string               `json:"id"`
-	Name        string               `json:"name"`
-	Description string               `json:"description"`
-	Free        *bool                `json:"free,omitempty"`
-	Bindable    *bool                `json:"bindable,omitempty"`
-	Metadata    *ServicePlanMetadata `json:"metadata,omitempty"`
-	Schemas     *ServiceSchemas      `json:"schemas,omitempty"`
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Free        *bool           `json:"free,omitempty"`
+	Bindable    *bool           `json:"bindable,omitempty"`
+	Metadata    interface{}     `json:"metadata,omitempty"`
+	Schemas     *ServiceSchemas `json:"schemas,omitempty"`
 }
 
 type ServiceSchemas struct {

--- a/service_broker.go
+++ b/service_broker.go
@@ -45,6 +45,10 @@ func (d BindDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
 
+func (d UpdateDetails) GetRawContext() json.RawMessage {
+	return d.RawContext
+}
+
 func (d UpdateDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
@@ -104,6 +108,7 @@ type UpdateDetails struct {
 	PlanID         string          `json:"plan_id"`
 	RawParameters  json.RawMessage `json:"parameters,omitempty"`
 	PreviousValues PreviousValues  `json:"previous_values"`
+	RawContext     json.RawMessage `json:"context,omitempty"`
 }
 
 type PreviousValues struct {


### PR DESCRIPTION
The Open Service Broker specification specifies that the Metadata fields
in the [catalog response](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#catalog-management) are opaque objects. There is a [convention](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/profile.md#service-metadata) that
the specification recommends be adhered to, which matches the structs
defined in this library (ServiceMetadata and ServicePlanMetadata), but
this convention is not mandated by the specification.

Changing the Service and ServicePlan structs to accept an "interface{}"
as the relevant Metadata allows implementers to provide any metadata
information, including the existing structs. 

This proposed change is backwards compatible, but allows for more flexibility when using this library.