### PR TITLE
Adding context to UpdateDetails type

### DIFF
--- a/service_broker.go
+++ b/service_broker.go
@@ -104,6 +104,7 @@ type UpdateDetails struct {
 	PlanID         string          `json:"plan_id"`
 	RawParameters  json.RawMessage `json:"parameters,omitempty"`
 	PreviousValues PreviousValues  `json:"previous_values"`
+	RawContext     json.RawMessage `json:"context,omitempty"`
 }
 
 type PreviousValues struct {


### PR DESCRIPTION
Context is one of the fields supported by the open service broker API in the body of the update service instance request.