### PR TITLE
AdditionalMetadata field in plan and service metadata

### DIFF
--- a/catalog_test.go
+++ b/catalog_test.go
@@ -133,6 +133,47 @@ var _ = Describe("Catalog", func() {
 
 				Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
 			})
+
+			It("encodes the AdditionalMetadata fields in the metadata fields", func() {
+				metadata := brokerapi.ServicePlanMetadata{
+					Bullets:     []string{"hello", "its me"},
+					DisplayName: "name",
+					AdditionalMetadata: map[string]interface{}{
+						"foo": "bar",
+						"baz": 1,
+					},
+				}
+				jsonString := `{
+					"bullets":["hello", "its me"],
+					"displayName":"name",
+					"foo": "bar",
+					"baz": 1
+				}`
+
+				Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
+			})
+		})
+
+		Describe("JSON decoding", func() {
+			It("sets the AdditionalMetadata from unrecognized fields", func() {
+				metadata := brokerapi.ServicePlanMetadata{}
+				jsonString := `{"foo":["test"],"bar":"Some display name"}`
+
+				err := json.Unmarshal([]byte(jsonString), &metadata)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+				Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
+			})
+
+			It("does not include convention fields into additional metadata", func() {
+				metadata := brokerapi.ServicePlanMetadata{}
+				jsonString := `{"bullets":["test"],"displayName":"Some display name", "costs": [{"amount": {"usd": 649.0},"unit": "MONTHLY"}]}`
+
+				err := json.Unmarshal([]byte(jsonString), &metadata)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata.AdditionalMetadata).To(BeEmpty())
+
+			})
 		})
 	})
 
@@ -160,6 +201,51 @@ var _ = Describe("Catalog", func() {
 				}`
 
 				Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
+			})
+
+			It("encodes the AdditionalMetadata fields in the metadata fields", func() {
+				metadata := brokerapi.ServiceMetadata{
+					DisplayName: "name",
+					AdditionalMetadata: map[string]interface{}{
+						"foo": "bar",
+						"baz": 1,
+					},
+				}
+				jsonString := `{
+					"displayName":"name",
+					"foo": "bar",
+					"baz": 1
+				}`
+
+				Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
+			})
+		})
+		Describe("JSON decoding", func() {
+			It("sets the AdditionalMetadata from unrecognized fields", func() {
+				metadata := brokerapi.ServiceMetadata{}
+				jsonString := `{"foo":["test"],"bar":"Some display name"}`
+
+				err := json.Unmarshal([]byte(jsonString), &metadata)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+				Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
+			})
+
+			It("does not include convention fields into additional metadata", func() {
+				metadata := brokerapi.ServiceMetadata{}
+				jsonString := `{
+					"displayName":"Cassandra",
+					"longDescription":"A long description of Cassandra",
+					"documentationUrl":"doc",
+					"supportUrl":"support",
+					"imageUrl":"image",
+					"providerDisplayName":"display",
+					"shareable":true
+				}`
+				err := json.Unmarshal([]byte(jsonString), &metadata)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata.AdditionalMetadata).To(BeEmpty())
+
 			})
 		})
 	})


### PR DESCRIPTION
- allow to add custom field in the plan that can be retrieved from
catalog endpoint

Signed-off-by: Carlo Colombo <ccolombo@pivotal.io>