### PR TITLE
adds SpaceGuid to BindResource struct to enable handling of shared se…

### DIFF
--- a/service_broker.go
+++ b/service_broker.go
@@ -90,6 +90,7 @@ type BindDetails struct {
 
 type BindResource struct {
 	AppGuid            string `json:"app_guid,omitempty"`
+	SpaceGuid          string `json:"space_guid,omitempty"`
 	Route              string `json:"route,omitempty"`
 	CredentialClientID string `json:"credential_client_id,omitempty"`
 }


### PR DESCRIPTION
…rvice instances

CloudController sends the SpaceGuid in the BindResource part of the binding request.

According to the documentation (https://docs.cloudfoundry.org/services/enable-sharing.html#-binding-permissions-based-on-instance-sharing) this field combined with context.space_guid should be used to determine whether the bind request originates in the original or another space (the service was shared to). 