### PR TITLE
Add support for async. bind operations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,6 +81,16 @@
   revision = "c65b2f87fee37d1c7854c9164a450713c28d50cd"
 
 [[projects]]
+  name = "github.com/pivotal-cf/brokerapi"
+  packages = [
+    ".",
+    "auth",
+    "fakes"
+  ]
+  revision = "d1fcddd951a6776bc01659143dda6aca057e98b7"
+  version = "v2.0.4"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
@@ -127,6 +137,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f5bfe5f275adcd02ff0727a3f378547c393e64ad2de6a2ce7e21f4b617d83456"
+  inputs-digest = "45092a33e183a6dc6304f8e76a8f2e22031ef45ca85cb1f7d01653c149e3c774"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api.go
+++ b/api.go
@@ -24,7 +24,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
-	"github.com/liorokman/brokerapi/auth"
+	"github.com/pivotal-cf/brokerapi/auth"
 )
 
 const (

--- a/api_test.go
+++ b/api_test.go
@@ -29,8 +29,8 @@ import (
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/drewolson/testflight"
-	"github.com/liorokman/brokerapi"
-	"github.com/liorokman/brokerapi/fakes"
+	"github.com/pivotal-cf/brokerapi"
+	"github.com/pivotal-cf/brokerapi/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/api_test.go
+++ b/api_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Service Broker API", func() {
 		makeRequest := func(method, path, body string) *httptest.ResponseRecorder {
 			recorder := httptest.NewRecorder()
 			request, _ := http.NewRequest(method, path, strings.NewReader(body))
-			request.Header.Add("X-Broker-API-Version", "2.13")
+			request.Header.Add("X-Broker-API-Version", "2.14")
 			request.SetBasicAuth(credentials.Username, credentials.Password)
 			request = request.WithContext(ctx)
 			brokerAPI.ServeHTTP(recorder, request)
@@ -165,6 +165,16 @@ var _ = Describe("Service Broker API", func() {
 
 		Specify("an update endpoint which passes the request context to the broker", func() {
 			makeRequest("PATCH", "/v2/service_instances/instance-id", `{"service_id":"123"}`)
+			Expect(fakeServiceBroker.ReceivedContext).To(BeTrue())
+		})
+
+		Specify("a get binding operation endpoint which passes the request context to the broker", func() {
+			makeRequest("GET", "/v2/service_instances/instance-id/service_bindings/binding-id", "{}")
+			Expect(fakeServiceBroker.ReceivedContext).To(BeTrue())
+		})
+
+		Specify("a last binding operation endpoint which passes the request context to the broker", func() {
+			makeRequest("GET", "/v2/service_instances/instance-id/service_bindings/binding-id/last_operation", "{}")
 			Expect(fakeServiceBroker.ReceivedContext).To(BeTrue())
 		})
 
@@ -1199,11 +1209,56 @@ var _ = Describe("Service Broker API", func() {
 	})
 
 	Describe("binding lifecycle endpoint", func() {
-		makeBindingRequestWithSpecificAPIVersion := func(instanceID, bindingID string, details map[string]interface{}, apiVersion string) *testflight.Response {
+
+		makeLastBindingOperationRequestWithSpecificAPIVersion := func(instanceID, bindingID string, apiVersion string) *testflight.Response {
 			response := &testflight.Response{}
 			testflight.WithServer(brokerAPI, func(r *testflight.Requester) {
-				path := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s",
-					instanceID, bindingID)
+				path := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s/last_operation", instanceID, bindingID)
+
+				buffer := &bytes.Buffer{}
+
+				request, err := http.NewRequest("GET", path, buffer)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				if apiVersion != "" {
+					request.Header.Add("X-Broker-Api-Version", apiVersion)
+				}
+				request.Header.Add("Content-Type", "application/json")
+				request.SetBasicAuth("username", "password")
+
+				response = r.Do(request)
+			})
+			return response
+		}
+
+		makeGetBindingRequestWithSpecificAPIVersion := func(instanceID, bindingID string, apiVersion string) *testflight.Response {
+			response := &testflight.Response{}
+			testflight.WithServer(brokerAPI, func(r *testflight.Requester) {
+				path := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s", instanceID, bindingID)
+
+				buffer := &bytes.Buffer{}
+
+				request, err := http.NewRequest("GET", path, buffer)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				if apiVersion != "" {
+					request.Header.Add("X-Broker-Api-Version", apiVersion)
+				}
+				request.Header.Add("Content-Type", "application/json")
+				request.SetBasicAuth("username", "password")
+
+				response = r.Do(request)
+			})
+			return response
+		}
+
+		makeBindingRequestWithSpecificAPIVersion := func(instanceID, bindingID string, details map[string]interface{}, apiVersion string, async bool) *testflight.Response {
+			response := &testflight.Response{}
+			testflight.WithServer(brokerAPI, func(r *testflight.Requester) {
+				path := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s?accepts_incomplete=%v",
+					instanceID, bindingID, async)
 
 				buffer := &bytes.Buffer{}
 
@@ -1227,7 +1282,11 @@ var _ = Describe("Service Broker API", func() {
 		}
 
 		makeBindingRequest := func(instanceID, bindingID string, details map[string]interface{}) *testflight.Response {
-			return makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.10")
+			return makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.10", false)
+		}
+
+		makeAsyncBindingRequest := func(instanceID, bindingID string, details map[string]interface{}) *testflight.Response {
+			return makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.14", true)
 		}
 
 		Describe("binding", func() {
@@ -1256,28 +1315,28 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("missing header X-Broker-API-Version", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "")
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "", false)
 					Expect(response.StatusCode).To(Equal(412))
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
 				})
 
 				It("has wrong version of API", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "1.14")
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "1.14", false)
 					Expect(response.StatusCode).To(Equal(412))
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
 				})
 
 				It("missing service-id", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"plan_id": "123"}, "2.14")
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"plan_id": "123"}, "2.14", false)
 					Expect(response.StatusCode).To(Equal(400))
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.service-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("service_id missing"))
 				})
 
 				It("missing plan-id", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"service_id": "123"}, "2.14")
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"service_id": "123"}, "2.14", false)
 					Expect(response.StatusCode).To(Equal(400))
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.plan-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("plan_id missing"))
@@ -1359,14 +1418,14 @@ var _ = Describe("Service Broker API", func() {
 
 					Context("when the broker API version is 2.9", func() {
 						It("responds with an experimental volume mount", func() {
-							response := makeBindingRequestWithSpecificAPIVersion(uniqueInstanceID(), uniqueBindingID(), details, "2.9")
+							response := makeBindingRequestWithSpecificAPIVersion(uniqueInstanceID(), uniqueBindingID(), details, "2.9", false)
 							Expect(response.Body).To(MatchJSON(fixture("binding_with_experimental_volume_mounts.json")))
 						})
 					})
 
 					Context("when the broker API version is 2.8", func() {
 						It("responds with an experimental volume mount", func() {
-							response := makeBindingRequestWithSpecificAPIVersion(uniqueInstanceID(), uniqueBindingID(), details, "2.8")
+							response := makeBindingRequestWithSpecificAPIVersion(uniqueInstanceID(), uniqueBindingID(), details, "2.8", false)
 							Expect(response.Body).To(MatchJSON(fixture("binding_with_experimental_volume_mounts.json")))
 						})
 					})
@@ -1565,6 +1624,58 @@ var _ = Describe("Service Broker API", func() {
 					makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.interesting-failure"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("I failed in unique and interesting ways"))
+				})
+			})
+
+			Context("when an async binding is requested", func() {
+				var (
+					fakeAsyncServiceBroker *fakes.FakeAsyncServiceBroker
+				)
+				BeforeEach(func() {
+					fakeAsyncServiceBroker = &fakes.FakeAsyncServiceBroker{
+						FakeServiceBroker: *fakeServiceBroker,
+						ShouldBindAsync:   true,
+					}
+					brokerAPI = brokerapi.New(fakeAsyncServiceBroker, brokerLogger, credentials)
+				})
+
+				It("when the api version is before 2.14 for Bind request", func() {
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.13", true)
+					Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+				})
+
+				It("when the api version is before 2.14 for LastBindingOperation request", func() {
+					response := makeLastBindingOperationRequestWithSpecificAPIVersion(instanceID, bindingID, "1.13")
+					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					response = makeLastBindingOperationRequestWithSpecificAPIVersion(instanceID, bindingID, "2.13")
+					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+				})
+
+				It("when the api version is before 2.14 for GetBinding request", func() {
+					response := makeGetBindingRequestWithSpecificAPIVersion(instanceID, bindingID, "1.13")
+					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					response = makeGetBindingRequestWithSpecificAPIVersion(instanceID, bindingID, "2.13")
+					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+				})
+
+				It("it returns an appropriate status code and operation data", func() {
+					response := makeAsyncBindingRequest(instanceID, bindingID, details)
+					Expect(response.StatusCode).To(Equal(http.StatusAccepted))
+					Expect(response.Body).To(MatchJSON(fixture("async_bind_response.json")))
+				})
+
+				It("can be polled with lastBindingOperation", func() {
+					fakeAsyncServiceBroker.LastOperationState = "succeeded"
+					fakeAsyncServiceBroker.LastOperationDescription = "some description"
+					response := makeLastBindingOperationRequestWithSpecificAPIVersion(instanceID, bindingID, "2.14")
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.Body).To(MatchJSON(fixture("last_operation_succeeded.json")))
+				})
+
+				It("getBinding returns the binding for the async request", func() {
+					response := makeGetBindingRequestWithSpecificAPIVersion(instanceID, bindingID, "2.14")
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.Body).To(MatchJSON(fixture("binding.json")))
 				})
 			})
 		})

--- a/api_test.go
+++ b/api_test.go
@@ -29,10 +29,10 @@ import (
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/drewolson/testflight"
+	"github.com/liorokman/brokerapi"
+	"github.com/liorokman/brokerapi/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi"
-	"github.com/pivotal-cf/brokerapi/fakes"
 )
 
 var _ = Describe("Service Broker API", func() {
@@ -1439,9 +1439,9 @@ var _ = Describe("Service Broker API", func() {
 					It("calls Bind on the service broker with the bind_resource", func() {
 
 						details["bind_resource"] = map[string]interface{}{
-							"app_guid": "a-guid",
-							"space_guid": "a-space-guid",
-							"route": "route.cf-apps.com",
+							"app_guid":             "a-guid",
+							"space_guid":           "a-space-guid",
+							"route":                "route.cf-apps.com",
 							"credential_client_id": "some-credentials",
 						}
 

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/liorokman/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi"
 )
 
 var _ = Describe("Catalog", func() {

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/liorokman/brokerapi"
+	"github.com/pivotal-cf/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/liorokman/brokerapi"
+	"github.com/pivotal-cf/brokerapi"
 )
 
 type FakeServiceBroker struct {

--- a/fixtures/async_bind_response.json
+++ b/fixtures/async_bind_response.json
@@ -1,0 +1,3 @@
+{
+  "operation":"0xDEADBEEF"
+}

--- a/response.go
+++ b/response.go
@@ -44,6 +44,26 @@ type LastOperationResponse struct {
 	Description string             `json:"description,omitempty"`
 }
 
+type AsyncBindResponse struct {
+	OperationData string `json:"operation,omitempty"`
+}
+
+type BindingResponse struct {
+	Credentials     interface{}   `json:"credentials"`
+	SyslogDrainURL  string        `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string        `json:"route_service_url,omitempty"`
+	VolumeMounts    []VolumeMount `json:"volume_mounts,omitempty"`
+}
+
+type GetBindingResponse struct {
+	BindingResponse
+	Parameters interface{} `json:"parameters"`
+}
+
+type UnbindResponse struct {
+	OperationData string `json:"operation,omitempty"`
+}
+
 type ExperimentalVolumeMountBindingResponse struct {
 	Credentials     interface{}               `json:"credentials"`
 	SyslogDrainURL  string                    `json:"syslog_drain_url,omitempty"`

--- a/response.go
+++ b/response.go
@@ -57,7 +57,7 @@ type BindingResponse struct {
 
 type GetBindingResponse struct {
 	BindingResponse
-	Parameters interface{} `json:"parameters"`
+	Parameters interface{} `json:"parameters,omitempty"`
 }
 
 type UnbindResponse struct {

--- a/response_test.go
+++ b/response_test.go
@@ -18,7 +18,7 @@ package brokerapi_test
 import (
 	"encoding/json"
 
-	"github.com/liorokman/brokerapi"
+	"github.com/pivotal-cf/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/response_test.go
+++ b/response_test.go
@@ -18,9 +18,9 @@ package brokerapi_test
 import (
 	"encoding/json"
 
+	"github.com/liorokman/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi"
 )
 
 var _ = Describe("Catalog Response", func() {

--- a/response_test.go
+++ b/response_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Provisioning Response", func() {
 var _ = Describe("Binding Response", func() {
 	Describe("JSON encoding", func() {
 		It("has a credentials object", func() {
-			binding := brokerapi.Binding{}
+			binding := brokerapi.BindingResponse{}
 			jsonString := `{"credentials":null}`
 
 			Expect(json.Marshal(binding)).To(MatchJSON(jsonString))


### PR DESCRIPTION
This PR adds support in the library for implementing brokers which support the OSB 2.14 async. bind operations.

It adds an ``async`` parameter to the Bind callback, and adds the ``lastOperation`` for bindings and ``getBinding`` endpoints to the ``ServiceBroker`` interface.