### PR TITLE
Add missing pieces for supporting OSB 2.14 

### DIFF
--- a/api.go
+++ b/api.go
@@ -24,7 +24,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
-	"github.com/liorokman/brokerapi/auth"
+	"github.com/pivotal-cf/brokerapi/auth"
 )
 
 const (

--- a/api.go
+++ b/api.go
@@ -32,6 +32,7 @@ const (
 	deprovisionLogKey          = "deprovision"
 	bindLogKey                 = "bind"
 	getBindLogKey              = "getBinding"
+	getInstanceLogKey          = "getInstance"
 	unbindLogKey               = "unbind"
 	updateLogKey               = "update"
 	lastOperationLogKey        = "lastOperation"
@@ -294,7 +295,7 @@ func (h serviceBrokerHandler) update(w http.ResponseWriter, req *http.Request) {
 	}
 	h.respond(w, statusCode, UpdateResponse{
 		OperationData: updateServiceSpec.OperationData,
-		DashboardURL: updateServiceSpec.DashboardURL,
+		DashboardURL:  updateServiceSpec.DashboardURL,
 	})
 }
 
@@ -362,7 +363,7 @@ func (h serviceBrokerHandler) getInstance(w http.ResponseWriter, req *http.Reque
 	vars := mux.Vars(req)
 	instanceID := vars["instance_id"]
 
-	logger := h.logger.Session(getBindLogKey, lager.Data{
+	logger := h.logger.Session(getInstanceLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 	})
 
@@ -375,8 +376,9 @@ func (h serviceBrokerHandler) getInstance(w http.ResponseWriter, req *http.Reque
 		return
 	}
 	if versionCompatibility.Minor < 14 {
+		err = errors.New("get instance endpoint only supported starting with OSB version 2.14")
 		h.respond(w, http.StatusPreconditionFailed, ErrorResponse{
-			Description: "get instance endpoint only supported starting with OSB version 2.14",
+			Description: err.Error(),
 		})
 		logger.Error(apiVersionInvalidKey, err)
 		return

--- a/api_test.go
+++ b/api_test.go
@@ -29,10 +29,10 @@ import (
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/drewolson/testflight"
-	"github.com/liorokman/brokerapi"
-	"github.com/liorokman/brokerapi/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi"
+	"github.com/pivotal-cf/brokerapi/fakes"
 )
 
 var _ = Describe("Service Broker API", func() {

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/pivotal-cf/brokerapi"
+	"github.com/liorokman/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/liorokman/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi"
 )
 
 var _ = Describe("Catalog", func() {

--- a/failure_response_test.go
+++ b/failure_response_test.go
@@ -16,7 +16,7 @@
 package brokerapi_test
 
 import (
-	"github.com/pivotal-cf/brokerapi"
+	"github.com/liorokman/brokerapi"
 
 	"errors"
 
@@ -65,7 +65,7 @@ var _ = Describe("FailureResponse", func() {
 			Expect(newError.Error()).To(Equal("my error message and some more details"))
 			Expect(newError.ValidatedStatusCode(nil)).To(Equal(http.StatusForbidden))
 			Expect(newError.LoggerAction()).To(Equal(failureResponse.LoggerAction()))
-			
+
 			errorResponse, typeCast := newError.ErrorResponse().(brokerapi.ErrorResponse)
 			Expect(typeCast).To(BeTrue())
 			Expect(errorResponse.Error).To(Equal("some-key"))

--- a/failure_response_test.go
+++ b/failure_response_test.go
@@ -16,7 +16,7 @@
 package brokerapi_test
 
 import (
-	"github.com/liorokman/brokerapi"
+	"github.com/pivotal-cf/brokerapi"
 
 	"errors"
 

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/pivotal-cf/brokerapi"
+	"github.com/liorokman/brokerapi"
 )
 
 type FakeServiceBroker struct {
@@ -15,6 +15,7 @@ type FakeServiceBroker struct {
 	ProvisionedInstanceIDs   []string
 	DeprovisionedInstanceIDs []string
 	UpdatedInstanceIDs       []string
+	GetInstanceIDs           []string
 
 	BoundInstanceIDs    []string
 	BoundBindingIDs     []string
@@ -230,6 +231,24 @@ func (fakeBroker *FakeServiceBroker) Update(context context.Context, instanceID 
 	fakeBroker.UpdatedInstanceIDs = append(fakeBroker.UpdatedInstanceIDs, instanceID)
 	fakeBroker.AsyncAllowed = asyncAllowed
 	return brokerapi.UpdateServiceSpec{IsAsync: fakeBroker.ShouldReturnAsync, OperationData: fakeBroker.OperationDataToReturn}, nil
+}
+
+func (fakeBroker *FakeServiceBroker) GetInstance(context context.Context, instanceID string) (brokerapi.GetInstanceDetailsSpec, error) {
+	fakeBroker.BrokerCalled = true
+
+	if val, ok := context.Value("test_context").(bool); ok {
+		fakeBroker.ReceivedContext = val
+	}
+
+	fakeBroker.GetInstanceIDs = append(fakeBroker.GetInstanceIDs, instanceID)
+	return brokerapi.GetInstanceDetailsSpec{
+		ServiceID:    fakeBroker.ServiceID,
+		PlanID:       fakeBroker.PlanID,
+		DashboardURL: fakeBroker.DashboardURL,
+		Parameters: map[string]interface{}{
+			"param1": "value1",
+		},
+	}, nil
 }
 
 func (fakeBroker *FakeServiceBroker) Deprovision(context context.Context, instanceID string, details brokerapi.DeprovisionDetails, asyncAllowed bool) (brokerapi.DeprovisionServiceSpec, error) {

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -34,6 +34,7 @@ type FakeServiceBroker struct {
 	DeprovisionError   error
 	LastOperationError error
 	UpdateError        error
+	GetInstanceError   error
 
 	BrokerCalled             bool
 	LastOperationState       brokerapi.LastOperationState
@@ -248,7 +249,7 @@ func (fakeBroker *FakeServiceBroker) GetInstance(context context.Context, instan
 		Parameters: map[string]interface{}{
 			"param1": "value1",
 		},
-	}, nil
+	}, fakeBroker.GetInstanceError
 }
 
 func (fakeBroker *FakeServiceBroker) Deprovision(context context.Context, instanceID string, details brokerapi.DeprovisionDetails, asyncAllowed bool) (brokerapi.DeprovisionServiceSpec, error) {

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/liorokman/brokerapi"
+	"github.com/pivotal-cf/brokerapi"
 )
 
 type FakeServiceBroker struct {

--- a/fixtures/get_instance.json
+++ b/fixtures/get_instance.json
@@ -1,0 +1,8 @@
+{
+    "service_id" : "0A789746-596F-4CEA-BFAC-A0795DA056E3",
+    "plan_id" : "plan-id",
+    "dashboard_url" : "https://example.com/dashboard/some-instance",
+    "parameters": {
+			"param1" : "value1"
+    }
+}

--- a/response.go
+++ b/response.go
@@ -41,7 +41,6 @@ type GetInstanceResponse struct {
 type UpdateResponse struct {
 	DashboardURL  string `json:"dashboard_url,omitempty"`
 	OperationData string `json:"operation,omitempty"`
-	DashboardURL  string `json:"dashboard_url,omitempty"`
 }
 
 type DeprovisionResponse struct {

--- a/response.go
+++ b/response.go
@@ -31,8 +31,16 @@ type ProvisioningResponse struct {
 	OperationData string `json:"operation,omitempty"`
 }
 
+type GetInstanceResponse struct {
+	ServiceID    string      `json:"service_id"`
+	PlanID       string      `json:"plan_id"`
+	DashboardURL string      `json:"dashboard_url,omitempty"`
+	Parameters   interface{} `json:"parameters,omitempty"`
+}
+
 type UpdateResponse struct {
 	OperationData string `json:"operation,omitempty"`
+	DashboardURL  string `json:"dashboard_url,omitempty"`
 }
 
 type DeprovisionResponse struct {

--- a/response_test.go
+++ b/response_test.go
@@ -18,9 +18,9 @@ package brokerapi_test
 import (
 	"encoding/json"
 
-	"github.com/liorokman/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi"
 )
 
 var _ = Describe("Catalog Response", func() {

--- a/response_test.go
+++ b/response_test.go
@@ -18,7 +18,7 @@ package brokerapi_test
 import (
 	"encoding/json"
 
-	"github.com/pivotal-cf/brokerapi"
+	"github.com/liorokman/brokerapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/service_broker.go
+++ b/service_broker.go
@@ -119,7 +119,6 @@ type UpdateServiceSpec struct {
 	IsAsync       bool
 	DashboardURL  string
 	OperationData string
-	DashboardURL  string
 }
 
 type DeprovisionServiceSpec struct {

--- a/service_broker.go
+++ b/service_broker.go
@@ -27,6 +27,7 @@ type ServiceBroker interface {
 
 	Provision(ctx context.Context, instanceID string, details ProvisionDetails, asyncAllowed bool) (ProvisionedServiceSpec, error)
 	Deprovision(ctx context.Context, instanceID string, details DeprovisionDetails, asyncAllowed bool) (DeprovisionServiceSpec, error)
+	GetInstance(ctx context.Context, instanceID string) (GetInstanceDetailsSpec, error)
 
 	Bind(ctx context.Context, instanceID, bindingID string, details BindDetails, asyncAllowed bool) (Binding, error)
 	Unbind(ctx context.Context, instanceID, bindingID string, details UnbindDetails, asyncAllowed bool) (UnbindSpec, error)
@@ -81,6 +82,13 @@ type ProvisionedServiceSpec struct {
 	OperationData string
 }
 
+type GetInstanceDetailsSpec struct {
+	ServiceID    string      `json:"service_id"`
+	PlanID       string      `json:"plan_id"`
+	DashboardURL string      `json:"dashboard_url"`
+	Parameters   interface{} `json:"parameters"`
+}
+
 type UnbindSpec struct {
 	IsAsync       bool
 	OperationData string
@@ -110,6 +118,7 @@ type UnbindDetails struct {
 type UpdateServiceSpec struct {
 	IsAsync       bool
 	OperationData string
+	DashboardURL  string
 }
 
 type DeprovisionServiceSpec struct {
@@ -199,6 +208,7 @@ const (
 	planChangeUnsupportedMsg    = "The requested plan migration cannot be performed"
 	rawInvalidParamsMsg         = "The format of the parameters is not valid JSON"
 	appGuidMissingMsg           = "app_guid is a required field but was not provided"
+	concurrentInstanceAccessMsg = "instance is being updated and cannot be retrieved"
 )
 
 var (
@@ -244,4 +254,8 @@ var (
 
 	ErrPlanQuotaExceeded    = errors.New(servicePlanQuotaExceededMsg)
 	ErrServiceQuotaExceeded = errors.New(serviceQuotaExceededMsg)
+
+	ErrConcurrentInstanceAccess = NewFailureResponseBuilder(
+		errors.New(concurrentInstanceAccessMsg), http.StatusUnprocessableEntity, concurrentAccessKey,
+	).WithErrorKey("ConcurrencyError")
 )


### PR DESCRIPTION

Added:

1. Support for the GetService endpoint (https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#fetching-a-service-instance) 
2. Support for allowing the broker to get an updated dashboard-url in update operations ( https://github.com/openservicebrokerapi/servicebroker/pull/437 ).

I think that with these two pieces, the brokerapi library supports OSB version 2.14 .