### PR TITLE
Add limited support for Originating Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Alternatively, if you already have a `*mux.Router` that you want to attach servi
 
 `NewFailureResponse()` allows you to return a custom error from any of the `ServiceBroker` interface methods which return an error. Within this you must define an error, a HTTP response status code and a logging key. You can also use the `NewFailureResponseBuilder()` to add a custom `Error:` value in the response, or indicate that the broker should return an empty response rather than the error message.
 
+## Originating Identity
+
+The request context for every request contains the unparsed `X-Broker-API-Originating-Identity` header under the key `originatingIdentityKey`.
+More details on how the Open Service Broker API manages request originating identity is available [here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#originating-identity).
+
 ## Example Service Broker
 
 You can see the [cf-redis](https://github.com/pivotal-cf/cf-redis-broker/blob/2f0e9a8ebb1012a9be74bbef2d411b0b3b60352f/broker/broker.go) service broker uses the BrokerAPI package to create a service broker for Redis.

--- a/api.go
+++ b/api.go
@@ -16,6 +16,7 @@
 package brokerapi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,6 +39,8 @@ const (
 	lastOperationLogKey        = "lastOperation"
 	lastBindingOperationLogKey = "lastBindingOperation"
 	catalogLogKey              = "catalog"
+
+	originatingIdentityKey = "originatingIdentity"
 
 	instanceIDLogKey      = "instance-id"
 	instanceDetailsLogKey = "instance-details"
@@ -79,7 +82,10 @@ type BrokerCredentials struct {
 func New(serviceBroker ServiceBroker, logger lager.Logger, brokerCredentials BrokerCredentials) http.Handler {
 	router := mux.NewRouter()
 	AttachRoutes(router, serviceBroker, logger)
-	return auth.NewWrapper(brokerCredentials.Username, brokerCredentials.Password).Wrap(router)
+
+	authMiddleware := auth.NewWrapper(brokerCredentials.Username, brokerCredentials.Password).Wrap
+	router.Use(authMiddleware, brokerApiOriginatingIdentityMiddleware)
+	return router
 }
 
 func AttachRoutes(router *mux.Router, serviceBroker ServiceBroker, logger lager.Logger) {
@@ -790,4 +796,12 @@ func checkBrokerAPIVersionHdr(req *http.Request) (brokerVersion, error) {
 		return version, errors.New("X-Broker-API-Version Header must be 2.x")
 	}
 	return version, nil
+}
+
+func brokerApiOriginatingIdentityMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		originatingIdentity := req.Header.Get("X-Broker-API-Originating-Identity")
+		newCtx := context.WithValue(req.Context(), originatingIdentityKey, originatingIdentity)
+		next.ServeHTTP(w, req.WithContext(newCtx))
+	})
 }


### PR DESCRIPTION
Adds middleware that parse the `https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#originating-identity` and adds it as a value to the downstream context.

Initially considered adding it to the structs details structs that are passed to service broker methods, but some requests (such as the catalog request) don't take any params other than the context.

Advice on testing this appropriately would be appreciated.