### PR TITLE
Capture  X-Api-Info-Location header in all broker requests

### DIFF
--- a/api.go
+++ b/api.go
@@ -41,6 +41,7 @@ func New(serviceBroker ServiceBroker, logger lager.Logger, brokerCredentials Bro
 	router.Use(authMiddleware)
 	router.Use(middlewares.AddOriginatingIdentityToContext)
 	router.Use(apiVersionMiddleware.ValidateAPIVersionHdr)
+	router.Use(middlewares.AddInfoLocationToContext)
 
 	return router
 }

--- a/middlewares/info_location_header.go
+++ b/middlewares/info_location_header.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2015-Present Pivotal Software, Inc. All rights reserved.
+
+// This program and the accompanying materials are made available under
+// the terms of the under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middlewares
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	infoLocationKey = "infoLocation"
+)
+
+func AddInfoLocationToContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		infoLocation := req.Header.Get("X-Api-Info-Location")
+		newCtx := context.WithValue(req.Context(), infoLocationKey, infoLocation)
+		next.ServeHTTP(w, req.WithContext(newCtx))
+	})
+}


### PR DESCRIPTION
Add infoLocation to context. This will allow to ping back the platform and obtain additional details if required.