### PR TITLE
Use releases of Gomega and Ginkgo rather than master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,8 +47,21 @@
   version = "v1.6.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:8df8625c851c00c5c55a8cde64323d203fd1221a8ea3e137ad2d05d01945ca55"
+  digest = "1:b3c5b95e56c06f5aa72cb2500e6ee5f44fcd122872d4fec2023a488e561218bc"
+  name = "github.com/hpcloud/tail"
+  packages = [
+    ".",
+    "ratelimiter",
+    "util",
+    "watch",
+    "winfile",
+  ]
+  pruneopts = ""
+  revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:38805c64ce8a1f932fb23bf1392709732ff4addfd9e72671ae09e6be206645df"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -72,11 +85,11 @@
     "types",
   ]
   pruneopts = ""
-  revision = "9008c7b79f9636c46a0a945141020124702f0ecf"
+  revision = "7e8b50db0c6d0a15ac0eb015d4ca64e7e7e2c88c"
+  version = "v1.9.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:44c1e18198c748e250810263a25205168c1cb452bdd8b850c40ef93b92ab4c7d"
+  digest = "1:fd4a6c768782f9e0cfd663eeb0bc8cf52c98fd23ead2aee6eb89a0eb4fb577b7"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -94,7 +107,8 @@
     "types",
   ]
   pruneopts = ""
-  revision = "49e4233a3b46c26dddd43cf84547cf31c92d0f2b"
+  revision = "27d50ea6455b212cf516609fa58b2b5dce1abc81"
+  version = "v1.6.0"
 
 [[projects]]
   branch = "master"
@@ -156,6 +170,23 @@
   pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
+
+[[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
+  name = "gopkg.in/fsnotify.v1"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "gopkg.in/fsnotify/fsnotify.v1"
+  version = "v1.4.7"
+
+[[projects]]
+  branch = "v1"
+  digest = "1:a96d16bd088460f2e0685d46c39bcf1208ba46e0a977be2df49864ec7da447dd"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  pruneopts = ""
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
   digest = "1:59925e8b791ee90b60e4dc05099d34fd38d0922a2a8f9b4e700cb61fc421e6b2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,11 +35,11 @@
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"
-  branch = "master"
+  version = "^1.9.0"
 
 [[constraint]]
   name = "github.com/onsi/gomega"
-  branch = "master"
+  version = "^1.6.0"
 
 [[constraint]]
   branch = "master"
@@ -48,3 +48,7 @@
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "^0.8.0"
+
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "gopkg.in/fsnotify/fsnotify.v1"


### PR DESCRIPTION
Ginkgo and Gomega produce regular versions, so it's
more reproducible to use version numbers than to work
off master. A version bumper (like Dependabot) can be
used to stay up to date.

code.cloudfoundry.org/lager does not seem to produce
regular versions, so it makes sense to keep working off
master for this dependency.