### PR TITLE
Disables HTML encoding for JSON responses

### DIFF
--- a/handlers/api_handler.go
+++ b/handlers/api_handler.go
@@ -42,6 +42,7 @@ func (h APIHandler) respond(w http.ResponseWriter, status int, response interfac
 	w.WriteHeader(status)
 
 	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(response)
 	if err != nil {
 		h.logger.Error("encoding response", err, lager.Data{"status": status, "response": response})


### PR DESCRIPTION
When returning binding information from the broker, connection strings containing ampersands and other HTML escapable characters arrive escaped to PCF.

We recommend disabling the HTML escape in the JSON encoding process.