### PR TITLE
Fix logger data enrichment

### DIFF
--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const (
@@ -22,13 +22,10 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 	instanceID := vars["instance_id"]
 	bindingID := vars["binding_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(bindLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		bindingIDLogKey:              bindingID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+		bindingIDLogKey:  bindingID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	version := getAPIVersion(req)
 	asyncAllowed := false

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -25,7 +25,7 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 	logger := h.logger.Session(bindLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 		bindingIDLogKey:  bindingID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	version := getAPIVersion(req)
 	asyncAllowed := false

--- a/handlers/deprovision.go
+++ b/handlers/deprovision.go
@@ -3,12 +3,12 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const deprovisionLogKey = "deprovision"
@@ -17,12 +17,9 @@ func (h APIHandler) Deprovision(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	instanceID := vars["instance_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(deprovisionLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	details := domain.DeprovisionDetails{
 		PlanID:    req.FormValue("plan_id"),

--- a/handlers/deprovision.go
+++ b/handlers/deprovision.go
@@ -19,7 +19,7 @@ func (h APIHandler) Deprovision(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(deprovisionLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	details := domain.DeprovisionDetails{
 		PlanID:    req.FormValue("plan_id"),

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -21,7 +21,7 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 	logger := h.logger.Session(getBindLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 		bindingIDLogKey:  bindingID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	version := getAPIVersion(req)
 	if version.Minor < 14 {

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const getBindLogKey = "getBinding"
@@ -18,13 +18,10 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 	instanceID := vars["instance_id"]
 	bindingID := vars["binding_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(getBindLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		bindingIDLogKey:              bindingID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+		bindingIDLogKey:  bindingID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	version := getAPIVersion(req)
 	if version.Minor < 14 {

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -19,7 +19,7 @@ func (h APIHandler) GetInstance(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(getInstanceLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	version := getAPIVersion(req)
 	if version.Minor < 14 {

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const getInstanceLogKey = "getInstance"
@@ -17,12 +17,9 @@ func (h APIHandler) GetInstance(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	instanceID := vars["instance_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(getInstanceLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	version := getAPIVersion(req)
 	if version.Minor < 14 {

--- a/handlers/last_binding_operation.go
+++ b/handlers/last_binding_operation.go
@@ -26,7 +26,7 @@ func (h APIHandler) LastBindingOperation(w http.ResponseWriter, req *http.Reques
 
 	logger := h.logger.Session(lastBindingOperationLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	version := getAPIVersion(req)
 	if version.Minor < 14 {

--- a/handlers/last_binding_operation.go
+++ b/handlers/last_binding_operation.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const lastBindingOperationLogKey = "lastBindingOperation"
@@ -24,12 +24,9 @@ func (h APIHandler) LastBindingOperation(w http.ResponseWriter, req *http.Reques
 		OperationData: req.FormValue("operation"),
 	}
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(lastBindingOperationLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	version := getAPIVersion(req)
 	if version.Minor < 14 {

--- a/handlers/last_operation.go
+++ b/handlers/last_operation.go
@@ -3,12 +3,12 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const lastOperationLogKey = "lastOperation"
@@ -22,12 +22,9 @@ func (h APIHandler) LastOperation(w http.ResponseWriter, req *http.Request) {
 		OperationData: req.FormValue("operation"),
 	}
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(lastOperationLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	logger.Info("starting-check-for-operation")
 

--- a/handlers/last_operation.go
+++ b/handlers/last_operation.go
@@ -24,7 +24,7 @@ func (h APIHandler) LastOperation(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(lastOperationLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	logger.Info("starting-check-for-operation")
 

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -27,7 +27,7 @@ func (h *APIHandler) Provision(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(provisionLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	var details domain.ProvisionDetails
 	if err := json.NewDecoder(req.Body).Decode(&details); err != nil {

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
 	"github.com/pivotal-cf/brokerapi/utils"
 )
 
@@ -26,12 +25,9 @@ func (h *APIHandler) Provision(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	instanceID := vars["instance_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(provisionLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	var details domain.ProvisionDetails
 	if err := json.NewDecoder(req.Body).Decode(&details); err != nil {

--- a/handlers/unbind.go
+++ b/handlers/unbind.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
 	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const unbindLogKey = "unbind"
@@ -18,13 +19,10 @@ func (h APIHandler) Unbind(w http.ResponseWriter, req *http.Request) {
 	instanceID := vars["instance_id"]
 	bindingID := vars["binding_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(unbindLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		bindingIDLogKey:              bindingID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+		bindingIDLogKey:  bindingID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	version := getAPIVersion(req)
 	asyncAllowed := req.FormValue("accepts_incomplete") == "true"

--- a/handlers/unbind.go
+++ b/handlers/unbind.go
@@ -22,7 +22,7 @@ func (h APIHandler) Unbind(w http.ResponseWriter, req *http.Request) {
 	logger := h.logger.Session(unbindLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 		bindingIDLogKey:  bindingID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	version := getAPIVersion(req)
 	asyncAllowed := req.FormValue("accepts_incomplete") == "true"

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -21,7 +21,7 @@ func (h APIHandler) Update(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(updateLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
 
 	var details domain.UpdateDetails
 	if err := json.NewDecoder(req.Body).Decode(&details); err != nil {

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/pivotal-cf/brokerapi/middlewares"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/middlewares"
+	"github.com/pivotal-cf/brokerapi/utils"
 )
 
 const updateLogKey = "update"
@@ -19,12 +19,9 @@ func (h APIHandler) Update(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	instanceID := vars["instance_id"]
 
-	correlationID := req.Context().Value(middlewares.CorrelationIDKey).(string)
-
 	logger := h.logger.Session(updateLogKey, lager.Data{
-		instanceIDLogKey:             instanceID,
-		middlewares.CorrelationIDKey: correlationID,
-	})
+		instanceIDLogKey: instanceID,
+	}, utils.DataForContext(req.Context(), []string{middlewares.CorrelationIDKey}))
 
 	var details domain.UpdateDetails
 	if err := json.NewDecoder(req.Body).Decode(&details); err != nil {

--- a/utils/context.go
+++ b/utils/context.go
@@ -42,11 +42,11 @@ func RetrieveServicePlanFromContext(ctx context.Context) *domain.ServicePlan {
 	return nil
 }
 
-func DataForContext(context context.Context, dataKeys []string) lager.Data {
+func DataForContext(context context.Context, dataKeys ...string) lager.Data {
 	data := lager.Data{}
 	for _, key := range dataKeys {
 		if value := context.Value(key); value != nil {
-			data[key] = value.(string)
+			data[key] = value
 		}
 	}
 

--- a/utils/context.go
+++ b/utils/context.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/pivotal-cf/brokerapi/domain"
 )
 
@@ -39,4 +40,15 @@ func RetrieveServicePlanFromContext(ctx context.Context) *domain.ServicePlan {
 		return value.(*domain.ServicePlan)
 	}
 	return nil
+}
+
+func DataForContext(context context.Context, dataKeys []string) lager.Data {
+	data := lager.Data{}
+	for _, key := range dataKeys {
+		if value := context.Value(key); value != nil {
+			data[key] = value.(string)
+		}
+	}
+
+	return data
 }

--- a/utils/context_test.go
+++ b/utils/context_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/brokerapi/domain"
+	"github.com/pivotal-cf/brokerapi/middlewares"
 	"github.com/pivotal-cf/brokerapi/utils"
 )
 
@@ -70,6 +71,27 @@ var _ = Describe("Context", func() {
 				Expect(ctx.Err()).To(BeZero())
 				Expect(ctx.Value(contextValidatorKey).(string)).To(Equal(contextValidatorValue))
 				Expect(utils.RetrieveServicePlanFromContext(ctx).ID).To(Equal(plan.ID))
+			})
+		})
+	})
+
+	Describe("Log data for context", func() {
+		Context("the provided key is present in the context", func() {
+			It("returns data containing the key", func() {
+				expectedValue := "123"
+				ctx = context.WithValue(ctx, middlewares.CorrelationIDKey, expectedValue)
+
+				data := utils.DataForContext(ctx, []string{middlewares.CorrelationIDKey})
+				correlationID, ok := data[middlewares.CorrelationIDKey]
+				Expect(ok).To(BeTrue())
+				Expect(correlationID).Should(Equal(expectedValue))
+			})
+		})
+		Context("the provided key is not in the context", func() {
+			It("returns data without the key", func() {
+				data := utils.DataForContext(ctx, []string{middlewares.CorrelationIDKey})
+				_, ok := data[middlewares.CorrelationIDKey]
+				Expect(ok).To(BeFalse())
 			})
 		})
 	})

--- a/utils/context_test.go
+++ b/utils/context_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/brokerapi/domain"
-	"github.com/pivotal-cf/brokerapi/middlewares"
 	"github.com/pivotal-cf/brokerapi/utils"
 )
 
@@ -76,21 +75,35 @@ var _ = Describe("Context", func() {
 	})
 
 	Describe("Log data for context", func() {
+		const testKey = "test-key"
+
 		Context("the provided key is present in the context", func() {
 			It("returns data containing the key", func() {
 				expectedValue := "123"
-				ctx = context.WithValue(ctx, middlewares.CorrelationIDKey, expectedValue)
+				ctx = context.WithValue(ctx, testKey, expectedValue)
 
-				data := utils.DataForContext(ctx, []string{middlewares.CorrelationIDKey})
-				correlationID, ok := data[middlewares.CorrelationIDKey]
+				data := utils.DataForContext(ctx, testKey)
+				value, ok := data[testKey]
 				Expect(ok).To(BeTrue())
-				Expect(correlationID).Should(Equal(expectedValue))
+				Expect(value).Should(Equal(expectedValue))
+			})
+			Context("the key value is a struct", func() {
+				It("returns data containing the key", func() {
+					type testType struct{}
+					expectedValue := testType{}
+					ctx = context.WithValue(ctx, testKey, expectedValue)
+
+					data := utils.DataForContext(ctx, testKey)
+					value, ok := data[testKey]
+					Expect(ok).To(BeTrue())
+					Expect(value).Should(Equal(expectedValue))
+				})
 			})
 		})
 		Context("the provided key is not in the context", func() {
 			It("returns data without the key", func() {
-				data := utils.DataForContext(ctx, []string{middlewares.CorrelationIDKey})
-				_, ok := data[middlewares.CorrelationIDKey]
+				data := utils.DataForContext(ctx, testKey)
+				_, ok := data[testKey]
 				Expect(ok).To(BeFalse())
 			})
 		})


### PR DESCRIPTION
My colleague @ataleksandrov recently contributed [this PR](https://github.com/pivotal-cf/brokerapi/pull/82) where a correlation/request ID is added to the request context. Then in every OSB operation handler, that ID is added as a data property to the logger.

Unfortunately, we've noticed that if one uses [`AttachRoutes`](https://github.com/pivotal-cf/brokerapi/blob/master/api.go#L50) instead of [`New`](https://github.com/pivotal-cf/brokerapi/blob/master/api.go#L33) for its broker, the [correlation ID middleware](https://github.com/pivotal-cf/brokerapi/blob/master/middlewares/correlation_id_header.go) is never "attached" (like every other middleware, it should be explicitly added).
That results in `nil` pointer error when trying to cast the correlation ID, which is `nil`, to `string` in every OSB operation handler ([e.g.](https://github.com/pivotal-cf/brokerapi/blob/master/handlers/provision.go#L29)).

This PR wraps the data extraction from the context and if the key is not present in it, it won't add it as a log data field.
