### PR TITLE
Add GetRawContext method on UpdateDetails struct

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1024,8 +1024,10 @@ var _ = Describe("Service Broker API", func() {
 					})
 
 					It("calls update with details with raw context", func() {
-						Expect(fakeServiceBroker.UpdateDetails.RawContext).To(
-							Equal(json.RawMessage(`{"new-context":"new-context-value"}`)),
+						detailsWithRawContext := brokerapi.DetailsWithRawContext(fakeServiceBroker.UpdateDetails)
+						rawContext := detailsWithRawContext.GetRawContext()
+						Expect(string(rawContext)).To(
+							MatchJSON(`{"new-context":"new-context-value"}`),
 						)
 					})
 

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -202,6 +202,10 @@ func (d BindDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
 
+func (d UpdateDetails) GetRawContext() json.RawMessage {
+	return d.RawContext
+}
+
 func (d UpdateDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }


### PR DESCRIPTION
**Description** 
- Add GetRawParameters method on UpdateDetails struct

Currently, I'm not able to use the `DetailsWithRawContext` interface properly, because the `UpdateDetails` does not implement the required method.

```
// Invoking this method is not possible with UpdateDetails struct
func Foo(details DetailsWithRawParameters) {
	raw := details.GetRawParameters()
	// ...
}
```

Signed-off-by: Mateusz Szostok <szostok.mateusz@gmail.com>