### PR TITLE
feat: maximum_polling_duration was missing from ServicePlan

### DIFF
--- a/domain/service_catalog.go
+++ b/domain/service_catalog.go
@@ -24,14 +24,15 @@ type Service struct {
 }
 
 type ServicePlan struct {
-	ID              string               `json:"id"`
-	Name            string               `json:"name"`
-	Description     string               `json:"description"`
-	Free            *bool                `json:"free,omitempty"`
-	Bindable        *bool                `json:"bindable,omitempty"`
-	Metadata        *ServicePlanMetadata `json:"metadata,omitempty"`
-	Schemas         *ServiceSchemas      `json:"schemas,omitempty"`
-	MaintenanceInfo *MaintenanceInfo     `json:"maintenance_info,omitempty"`
+	ID                     string               `json:"id"`
+	Name                   string               `json:"name"`
+	Description            string               `json:"description"`
+	Free                   *bool                `json:"free,omitempty"`
+	Bindable               *bool                `json:"bindable,omitempty"`
+	Metadata               *ServicePlanMetadata `json:"metadata,omitempty"`
+	Schemas                *ServiceSchemas      `json:"schemas,omitempty"`
+	MaximumPollingDuration *int                 `json:"maximum_polling_duration,omitempty"`
+	MaintenanceInfo        *MaintenanceInfo     `json:"maintenance_info,omitempty"`
 }
 
 type ServiceSchemas struct {

--- a/domain/service_catalog_test.go
+++ b/domain/service_catalog_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pivotal-cf/brokerapi/v7/domain"
 )
 
+var maximumPollingDuration = 3600
+
 var _ = Describe("ServiceCatalog", func() {
 	Describe("Service", func() {
 		Describe("JSON encoding", func() {
@@ -104,7 +106,7 @@ var _ = Describe("ServiceCatalog", func() {
 						Bullets:     []string{"hello", "its me"},
 						DisplayName: "name",
 					},
-					MaximumPollingDuration: 3600,
+					MaximumPollingDuration: &maximumPollingDuration,
 					MaintenanceInfo: &domain.MaintenanceInfo{
 						Public: map[string]string{
 							"name": "foo",

--- a/domain/service_catalog_test.go
+++ b/domain/service_catalog_test.go
@@ -104,6 +104,7 @@ var _ = Describe("ServiceCatalog", func() {
 						Bullets:     []string{"hello", "its me"},
 						DisplayName: "name",
 					},
+					MaximumPollingDuration: 3600,
 					MaintenanceInfo: &domain.MaintenanceInfo{
 						Public: map[string]string{
 							"name": "foo",
@@ -123,6 +124,7 @@ var _ = Describe("ServiceCatalog", func() {
 						"bullets":["hello", "its me"],
 						"displayName":"name"
 					},
+					"maximum_polling_duration": 3600,
 					"maintenance_info": {
 						"public": {
 							"name": "foo"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/pivotal-cf/brokerapi/v7
 
+go 1.15
+
 require (
 	code.cloudfoundry.org/lager v1.1.1-0.20191008172124-a9afc05ee5be
 	github.com/drewolson/testflight v1.0.0

--- a/v7/domain/service_catalog.go
+++ b/v7/domain/service_catalog.go
@@ -24,14 +24,15 @@ type Service struct {
 }
 
 type ServicePlan struct {
-	ID              string               `json:"id"`
-	Name            string               `json:"name"`
-	Description     string               `json:"description"`
-	Free            *bool                `json:"free,omitempty"`
-	Bindable        *bool                `json:"bindable,omitempty"`
-	Metadata        *ServicePlanMetadata `json:"metadata,omitempty"`
-	Schemas         *ServiceSchemas      `json:"schemas,omitempty"`
-	MaintenanceInfo *MaintenanceInfo     `json:"maintenance_info,omitempty"`
+	ID                     string               `json:"id"`
+	Name                   string               `json:"name"`
+	Description            string               `json:"description"`
+	Free                   *bool                `json:"free,omitempty"`
+	Bindable               *bool                `json:"bindable,omitempty"`
+	Metadata               *ServicePlanMetadata `json:"metadata,omitempty"`
+	Schemas                *ServiceSchemas      `json:"schemas,omitempty"`
+	MaximumPollingDuration *int                 `json:"maximum_polling_duration,omitempty"`
+	MaintenanceInfo        *MaintenanceInfo     `json:"maintenance_info,omitempty"`
 }
 
 type ServiceSchemas struct {


### PR DESCRIPTION
Per spec we should be able to set the maximum_polling duration on the ServicePlan https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-plan-object
https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-interval-and-duration

