### PR TITLE
Add the request identity to the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,17 @@ func (sb *ServiceBrokerImplementation) Provision(ctx context.Context,
 
 The request context for every request contains the unparsed
 `X-Broker-API-Originating-Identity` header under the key
-`originatingIdentityKey`.  More details on how the Open Service Broker API
+`originatingIdentity`.  More details on how the Open Service Broker API
 manages request originating identity is available
 [here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#originating-identity).
+
+## Request Identity
+
+The request context for every request contains the unparsed
+`X-Broker-API-Request-Identity` header under the key
+`requestIdentity`.  More details on how the Open Service Broker API
+manages request originating identity is available
+[here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-identity).
 
 ## Example Service Broker
 

--- a/api.go
+++ b/api.go
@@ -43,6 +43,7 @@ func New(serviceBroker ServiceBroker, logger lager.Logger, brokerCredentials Bro
 	router.Use(middlewares.AddOriginatingIdentityToContext)
 	router.Use(apiVersionMiddleware.ValidateAPIVersionHdr)
 	router.Use(middlewares.AddInfoLocationToContext)
+	router.Use(middlewares.AddRequestIdentityToContext)
 
 	return router
 }

--- a/api_test.go
+++ b/api_test.go
@@ -305,6 +305,56 @@ var _ = Describe("Service Broker API", func() {
 		})
 	})
 
+	Describe("RequestIdentityHeader", func() {
+
+		var (
+			fakeServiceBroker *fakes.AutoFakeServiceBroker
+			req               *http.Request
+			testServer        *httptest.Server
+		)
+
+		BeforeEach(func() {
+			fakeServiceBroker = new(fakes.AutoFakeServiceBroker)
+			brokerAPI = brokerapi.New(fakeServiceBroker, brokerLogger, credentials)
+
+			testServer = httptest.NewServer(brokerAPI)
+			var err error
+			req, err = http.NewRequest("GET", testServer.URL+"/v2/catalog", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Add("X-Broker-API-Version", "2.14")
+			req.SetBasicAuth(credentials.Username, credentials.Password)
+		})
+
+		AfterEach(func() {
+			testServer.Close()
+		})
+
+		When("X-Broker-API-Request-Identity is passed", func() {
+			It("Adds it to the context", func() {
+				const requestIdentity = "Request Identity Name"
+				req.Header.Add("X-Broker-API-Request-Identity", requestIdentity)
+
+				_, err := http.DefaultClient.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeServiceBroker.ServicesCallCount()).To(Equal(1), "Services was not called")
+				ctx := fakeServiceBroker.ServicesArgsForCall(0)
+				Expect(ctx.Value("requestIdentity")).To(Equal(requestIdentity))
+
+			})
+		})
+		When("X-Broker-API-Request-Identity is not passed", func() {
+			It("Adds empty requestIdentity to the context", func() {
+				_, err := http.DefaultClient.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeServiceBroker.ServicesCallCount()).To(Equal(1), "Services was not called")
+				ctx := fakeServiceBroker.ServicesArgsForCall(0)
+				Expect(ctx.Value("requestIdentity")).To(Equal(""))
+			})
+		})
+	})
+
 	Describe("catalog endpoint", func() {
 		makeCatalogRequest := func(apiVersion string, fail bool) *httptest.ResponseRecorder {
 			recorder := httptest.NewRecorder()

--- a/middlewares/request_identity_header.go
+++ b/middlewares/request_identity_header.go
@@ -1,0 +1,16 @@
+package middlewares
+
+import (
+	"context"
+	"net/http"
+)
+
+const RequestIdentityKey = "requestIdentity"
+
+func AddRequestIdentityToContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestIdentity := req.Header.Get("X-Broker-API-Request-Identity")
+		newCtx := context.WithValue(req.Context(), RequestIdentityKey, requestIdentity)
+		next.ServeHTTP(w, req.WithContext(newCtx))
+	})
+}


### PR DESCRIPTION
This PR adds the [`X-Broker-API-Request-Identity`](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-identity) header to the request context.  
I exposes the `requestIdentity` context key as a public constant so that client code can refer to it more easily.

The PR also fixes a typo in the README.