### PR TITLE
Add metadata parameter to provisioning response body

### DIFF
--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -29,8 +29,9 @@ type CatalogResponse struct {
 }
 
 type ProvisioningResponse struct {
-	DashboardURL  string `json:"dashboard_url,omitempty"`
-	OperationData string `json:"operation,omitempty"`
+	DashboardURL  string      `json:"dashboard_url,omitempty"`
+	OperationData string      `json:"operation,omitempty"`
+	Metadata      interface{} `json:"metadata,omitempty"`
 }
 
 type GetInstanceResponse struct {

--- a/domain/apiresponses/responses_test.go
+++ b/domain/apiresponses/responses_test.go
@@ -43,6 +43,20 @@ var _ = Describe("Provisioning Response", func() {
 				Expect(json.Marshal(provisioningResponse)).To(MatchJSON(jsonString))
 			})
 		})
+
+		Context("when the metadata is present", func() {
+			It("returns it in the JSON", func() {
+				provisioningResponse := apiresponses.ProvisioningResponse{
+					Metadata: domain.Metadata{
+						Labels:     map[string]string{"key1": "value1"},
+						Attributes: map[string]string{"key1": "value1"},
+					},
+				}
+				jsonString := `{"metadata":{"labels":{"key1":"value1"}, "attributes":{"key1":"value1"}}}`
+
+				Expect(json.Marshal(provisioningResponse)).To(MatchJSON(jsonString))
+			})
+		})
 	})
 })
 

--- a/domain/apiresponses/responses_test.go
+++ b/domain/apiresponses/responses_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Provisioning Response", func() {
 		Context("when the metadata is present", func() {
 			It("returns it in the JSON", func() {
 				provisioningResponse := apiresponses.ProvisioningResponse{
-					Metadata: domain.Metadata{
+					Metadata: domain.InstanceMetadata{
 						Labels:     map[string]string{"key1": "value1"},
 						Attributes: map[string]string{"key1": "value1"},
 					},

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -94,10 +94,10 @@ type ProvisionedServiceSpec struct {
 	AlreadyExists bool
 	DashboardURL  string
 	OperationData string
-	Metadata      Metadata
+	Metadata      InstanceMetadata
 }
 
-type Metadata struct {
+type InstanceMetadata struct {
 	Labels     map[string]string `json:"labels,omitempty"`
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
@@ -211,7 +211,7 @@ func (d BindDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
 }
 
-func (m Metadata) ISEmpty() bool {
+func (m InstanceMetadata) IsEmpty() bool {
 	return len(m.Attributes) == 0 && len(m.Labels) == 0
 }
 

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -94,6 +94,12 @@ type ProvisionedServiceSpec struct {
 	AlreadyExists bool
 	DashboardURL  string
 	OperationData string
+	Metadata      Metadata
+}
+
+type Metadata struct {
+	Labels     map[string]string `json:"labels,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 type DeprovisionDetails struct {
@@ -203,6 +209,10 @@ func (d BindDetails) GetRawContext() json.RawMessage {
 
 func (d BindDetails) GetRawParameters() json.RawMessage {
 	return d.RawParameters
+}
+
+func (m Metadata) ISEmpty() bool {
+	return len(m.Attributes) == 0 && len(m.Labels) == 0
 }
 
 func (d UpdateDetails) GetRawContext() json.RawMessage {

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -111,18 +111,26 @@ func (h *APIHandler) Provision(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata interface{}
+	if !provisionResponse.Metadata.ISEmpty() {
+		metadata = provisionResponse.Metadata
+	}
+
 	if provisionResponse.AlreadyExists {
 		h.respond(w, http.StatusOK, apiresponses.ProvisioningResponse{
 			DashboardURL: provisionResponse.DashboardURL,
+			Metadata:     metadata,
 		})
 	} else if provisionResponse.IsAsync {
 		h.respond(w, http.StatusAccepted, apiresponses.ProvisioningResponse{
 			DashboardURL:  provisionResponse.DashboardURL,
 			OperationData: provisionResponse.OperationData,
+			Metadata:      metadata,
 		})
 	} else {
 		h.respond(w, http.StatusCreated, apiresponses.ProvisioningResponse{
 			DashboardURL: provisionResponse.DashboardURL,
+			Metadata:     metadata,
 		})
 	}
 }

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -112,7 +112,7 @@ func (h *APIHandler) Provision(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var metadata interface{}
-	if !provisionResponse.Metadata.ISEmpty() {
+	if !provisionResponse.Metadata.IsEmpty() {
 		metadata = provisionResponse.Metadata
 	}
 


### PR DESCRIPTION
Hi,

This PR adds an optional `metadata` field to the `ProvisioningResponse` according to the [specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#body-4)

Problem mentioned before in this [issue](https://github.com/pivotal-cf/brokerapi/issues/128)