### PR TITLE
fix: log 'X-Broker-API-Request-Identity' header value

### DIFF
--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -26,7 +26,7 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 	logger := h.logger.Session(bindLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 		bindingIDLogKey:  bindingID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	version := getAPIVersion(req)
 	asyncAllowed := false

--- a/handlers/deprovision.go
+++ b/handlers/deprovision.go
@@ -20,7 +20,7 @@ func (h APIHandler) Deprovision(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(deprovisionLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	details := domain.DeprovisionDetails{
 		PlanID:    req.FormValue("plan_id"),

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -23,7 +23,7 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 	logger := h.logger.Session(getBindLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 		bindingIDLogKey:  bindingID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	requestId := fmt.Sprintf("%v", req.Context().Value("requestIdentity"))
 

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -22,7 +22,7 @@ func (h APIHandler) GetInstance(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(getInstanceLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	requestId := fmt.Sprintf("%v", req.Context().Value("requestIdentity"))
 

--- a/handlers/last_binding_operation.go
+++ b/handlers/last_binding_operation.go
@@ -27,7 +27,7 @@ func (h APIHandler) LastBindingOperation(w http.ResponseWriter, req *http.Reques
 
 	logger := h.logger.Session(lastBindingOperationLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	requestId := fmt.Sprintf("%v", req.Context().Value("requestIdentity"))
 

--- a/handlers/last_operation.go
+++ b/handlers/last_operation.go
@@ -25,7 +25,7 @@ func (h APIHandler) LastOperation(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(lastOperationLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	logger.Info("starting-check-for-operation")
 

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -28,7 +28,7 @@ func (h *APIHandler) Provision(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(provisionLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	requestId := fmt.Sprintf("%v", req.Context().Value("requestIdentity"))
 

--- a/handlers/unbind.go
+++ b/handlers/unbind.go
@@ -22,7 +22,7 @@ func (h APIHandler) Unbind(w http.ResponseWriter, req *http.Request) {
 	logger := h.logger.Session(unbindLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
 		bindingIDLogKey:  bindingID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	requestId := fmt.Sprintf("%v", req.Context().Value("requestIdentity"))
 

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -22,7 +22,7 @@ func (h APIHandler) Update(w http.ResponseWriter, req *http.Request) {
 
 	logger := h.logger.Session(updateLogKey, lager.Data{
 		instanceIDLogKey: instanceID,
-	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey))
+	}, utils.DataForContext(req.Context(), middlewares.CorrelationIDKey, middlewares.RequestIdentityKey))
 
 	requestId := fmt.Sprintf("%v", req.Context().Value("requestIdentity"))
 


### PR DESCRIPTION
PR #148 started to read this header, but the value was not logged. To be
consistent with the correlation ID header (which is logged) we should
log the request ID too.

Note that correlation ID will be logged as `correlation-id` and request identity will be logged as `requestIdentity`. This is inconsistent, and would be much easier to tidy up after #155 is merged, because it introduces consistent use of a constant.