### PR TITLE
chore: consistently use "kebab case" for context key values

### DIFF
--- a/middlewares/context_keys.go
+++ b/middlewares/context_keys.go
@@ -4,7 +4,7 @@ type ContextKey string
 
 const (
 	CorrelationIDKey       ContextKey = "correlation-id"
-	InfoLocationKey        ContextKey = "infoLocation"
-	OriginatingIdentityKey ContextKey = "originatingIdentity"
-	RequestIdentityKey     ContextKey = "requestIdentity"
+	InfoLocationKey        ContextKey = "info-location"
+	OriginatingIdentityKey ContextKey = "originating-id"
+	RequestIdentityKey     ContextKey = "request-id"
 )


### PR DESCRIPTION
Since the types of the context keys were changed in #155 we might as
well take the chance to make them consistently be the same style.
Consumers who are not using a constant will need to make a change
anyway.

BREAKING CHANGE