### PR TITLE
Add metadata parameter to get and update response body

### DIFF
--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -39,11 +39,13 @@ type GetInstanceResponse struct {
 	PlanID       string      `json:"plan_id"`
 	DashboardURL string      `json:"dashboard_url,omitempty"`
 	Parameters   interface{} `json:"parameters,omitempty"`
+	Metadata     interface{} `json:"metadata,omitempty"`
 }
 
 type UpdateResponse struct {
-	DashboardURL  string `json:"dashboard_url,omitempty"`
-	OperationData string `json:"operation,omitempty"`
+	DashboardURL  string      `json:"dashboard_url,omitempty"`
+	OperationData string      `json:"operation,omitempty"`
+	Metadata      interface{} `json:"metadata,omitempty"`
 }
 
 type DeprovisionResponse struct {

--- a/domain/apiresponses/responses_test.go
+++ b/domain/apiresponses/responses_test.go
@@ -60,6 +60,40 @@ var _ = Describe("Provisioning Response", func() {
 	})
 })
 
+var _ = Describe("Fetching Response", func() {
+	Describe("JSON encoding", func() {
+		Context("when the dashboard URL and parameters are present", func() {
+			It("returns it in the JSON", func() {
+				fetchingResponse := apiresponses.GetInstanceResponse{
+					ServiceID:    "sID",
+					PlanID:       "pID",
+					DashboardURL: "http://example.com/broker",
+					Parameters:   map[string]string{"param1": "value1"},
+				}
+				jsonString := `{"service_id":"sID", "plan_id":"pID", "dashboard_url":"http://example.com/broker", "parameters": {"param1":"value1"}}`
+
+				Expect(json.Marshal(fetchingResponse)).To(MatchJSON(jsonString))
+			})
+		})
+
+		Context("when the metadata is present", func() {
+			It("returns it in the JSON", func() {
+				fetchingResponse := apiresponses.GetInstanceResponse{
+					ServiceID: "sID",
+					PlanID:    "pID",
+					Metadata: domain.InstanceMetadata{
+						Labels:     map[string]string{"key1": "value1"},
+						Attributes: map[string]string{"key1": "value1"},
+					},
+				}
+				jsonString := `{"service_id":"sID", "plan_id":"pID", "metadata":{"labels":{"key1":"value1"}, "attributes":{"key1":"value1"}}}`
+
+				Expect(json.Marshal(fetchingResponse)).To(MatchJSON(jsonString))
+			})
+		})
+	})
+})
+
 var _ = Describe("Update Response", func() {
 	Describe("JSON encoding", func() {
 		Context("when the dashboard URL is not present", func() {
@@ -77,6 +111,20 @@ var _ = Describe("Update Response", func() {
 					DashboardURL: "http://example.com/broker_updated",
 				}
 				jsonString := `{"dashboard_url":"http://example.com/broker_updated"}`
+
+				Expect(json.Marshal(updateResponse)).To(MatchJSON(jsonString))
+			})
+		})
+
+		Context("when the metadata is present", func() {
+			It("returns it in the JSON", func() {
+				updateResponse := apiresponses.UpdateResponse{
+					Metadata: domain.InstanceMetadata{
+						Labels:     map[string]string{"key1": "value1"},
+						Attributes: map[string]string{"key1": "value1"},
+					},
+				}
+				jsonString := `{"metadata":{"labels":{"key1":"value1"}, "attributes":{"key1":"value1"}}}`
 
 				Expect(json.Marshal(updateResponse)).To(MatchJSON(jsonString))
 			})

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -119,6 +119,7 @@ type GetInstanceDetailsSpec struct {
 	PlanID       string      `json:"plan_id"`
 	DashboardURL string      `json:"dashboard_url"`
 	Parameters   interface{} `json:"parameters"`
+	Metadata     InstanceMetadata
 }
 
 type UpdateDetails struct {
@@ -142,6 +143,7 @@ type UpdateServiceSpec struct {
 	IsAsync       bool
 	DashboardURL  string
 	OperationData string
+	Metadata      InstanceMetadata
 }
 
 type FetchInstanceDetails struct {

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -56,10 +56,16 @@ func (h APIHandler) GetInstance(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata interface{}
+	if !instanceDetails.Metadata.IsEmpty() {
+		metadata = instanceDetails.Metadata
+	}
+
 	h.respond(w, http.StatusOK, requestId, apiresponses.GetInstanceResponse{
 		ServiceID:    instanceDetails.ServiceID,
 		PlanID:       instanceDetails.PlanID,
 		DashboardURL: instanceDetails.DashboardURL,
 		Parameters:   instanceDetails.Parameters,
+		Metadata:     metadata,
 	})
 }

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -60,6 +60,11 @@ func (h APIHandler) Update(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata interface{}
+	if !updateServiceSpec.Metadata.IsEmpty() {
+		metadata = updateServiceSpec.Metadata
+	}
+
 	statusCode := http.StatusOK
 	if updateServiceSpec.IsAsync {
 		statusCode = http.StatusAccepted
@@ -67,5 +72,6 @@ func (h APIHandler) Update(w http.ResponseWriter, req *http.Request) {
 	h.respond(w, statusCode, requestId, apiresponses.UpdateResponse{
 		OperationData: updateServiceSpec.OperationData,
 		DashboardURL:  updateServiceSpec.DashboardURL,
+		Metadata:      metadata,
 	})
 }


### PR DESCRIPTION
Hi,

This PR adds an optional `metadata` field to the `FetchingResponse` and `UpdatingResponse` according to the specification for [Fetching a Service Instance](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#body-5) and [Updating a Service Instance](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#body-7)

It is a similar solution as for `ProvisioningResponse` in [this PR](https://github.com/pivotal-cf/brokerapi/pull/131)