### PR TITLE
Support custom authentication middleware implementations

### DIFF
--- a/api.go
+++ b/api.go
@@ -31,11 +31,15 @@ type BrokerCredentials struct {
 }
 
 func New(serviceBroker ServiceBroker, logger lager.Logger, brokerCredentials BrokerCredentials) http.Handler {
+	authMiddleware := auth.NewWrapper(brokerCredentials.Username, brokerCredentials.Password).Wrap
+	return NewWithCustomAuth(serviceBroker, logger, authMiddleware)
+}
+
+func NewWithCustomAuth(serviceBroker ServiceBroker, logger lager.Logger, authMiddleware mux.MiddlewareFunc) http.Handler {
 	router := mux.NewRouter()
 
 	AttachRoutes(router, serviceBroker, logger)
 
-	authMiddleware := auth.NewWrapper(brokerCredentials.Username, brokerCredentials.Password).Wrap
 	apiVersionMiddleware := middlewares.APIVersionMiddleware{LoggerFactory: logger}
 
 	router.Use(middlewares.AddCorrelationIDToContext)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -58,14 +58,14 @@ func (wrapper *Wrapper) Wrap(handler http.Handler) http.Handler {
 }
 
 func (wrapper *Wrapper) WrapFunc(handlerFunc http.HandlerFunc) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		if !authorized(wrapper, r) {
 			http.Error(w, notAuthorized, http.StatusUnauthorized)
 			return
 		}
 
 		handlerFunc(w, r)
-	})
+	}
 }
 
 func authorized(wrapper *Wrapper, r *http.Request) bool {


### PR DESCRIPTION
This commit provides the necessary means for projects building upon the
brokerapi to use their own authentication middleware, e.g. to provide
authentication based on Bearer tokens as defined in RFC 6750,
section 2.1.

Closes #158