### PR TITLE
Allow URL-encoded paths via options pattern

### DIFF
--- a/api.go
+++ b/api.go
@@ -20,9 +20,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/gorilla/mux"
-	"github.com/pivotal-cf/brokerapi/v8/auth"
 	"github.com/pivotal-cf/brokerapi/v8/handlers"
-	"github.com/pivotal-cf/brokerapi/v8/middlewares"
 )
 
 type BrokerCredentials struct {
@@ -31,28 +29,18 @@ type BrokerCredentials struct {
 }
 
 func New(serviceBroker ServiceBroker, logger lager.Logger, brokerCredentials BrokerCredentials) http.Handler {
-	authMiddleware := auth.NewWrapper(brokerCredentials.Username, brokerCredentials.Password).Wrap
-	return NewWithCustomAuth(serviceBroker, logger, authMiddleware)
+	return NewWithOptions(serviceBroker, logger, WithBrokerCredentials(brokerCredentials))
 }
 
 func NewWithCustomAuth(serviceBroker ServiceBroker, logger lager.Logger, authMiddleware mux.MiddlewareFunc) http.Handler {
-	router := mux.NewRouter()
-
-	AttachRoutes(router, serviceBroker, logger)
-
-	apiVersionMiddleware := middlewares.APIVersionMiddleware{LoggerFactory: logger}
-
-	router.Use(middlewares.AddCorrelationIDToContext)
-	router.Use(authMiddleware)
-	router.Use(middlewares.AddOriginatingIdentityToContext)
-	router.Use(apiVersionMiddleware.ValidateAPIVersionHdr)
-	router.Use(middlewares.AddInfoLocationToContext)
-	router.Use(middlewares.AddRequestIdentityToContext)
-
-	return router
+	return NewWithOptions(serviceBroker, logger, WithCustomAuth(authMiddleware))
 }
 
 func AttachRoutes(router *mux.Router, serviceBroker ServiceBroker, logger lager.Logger) {
+	NewWithOptions(serviceBroker, logger, WithRouter(router))
+}
+
+func attachRoutes(router *mux.Router, serviceBroker ServiceBroker, logger lager.Logger) {
 	apiHandler := handlers.NewApiHandler(serviceBroker, logger)
 	router.HandleFunc("/v2/catalog", apiHandler.Catalog).Methods("GET")
 

--- a/api.go
+++ b/api.go
@@ -37,7 +37,7 @@ func NewWithCustomAuth(serviceBroker ServiceBroker, logger lager.Logger, authMid
 }
 
 func AttachRoutes(router *mux.Router, serviceBroker ServiceBroker, logger lager.Logger) {
-	NewWithOptions(serviceBroker, logger, WithRouter(router))
+	attachRoutes(router, serviceBroker, logger)
 }
 
 func attachRoutes(router *mux.Router, serviceBroker ServiceBroker, logger lager.Logger) {

--- a/api_options.go
+++ b/api_options.go
@@ -54,6 +54,12 @@ func WithCustomAuth(authMiddleware mux.MiddlewareFunc) Option {
 	}
 }
 
+func WithEncodedPath() Option {
+	return func(c *config) {
+		c.router.UseEncodedPath()
+	}
+}
+
 func withDefaultMiddleware() Option {
 	return func(c *config) {
 		if !c.customRouter {

--- a/api_options.go
+++ b/api_options.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2015-Present Pivotal Software, Inc. All rights reserved.
+
+// This program and the accompanying materials are made available under
+// the terms of the under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brokerapi
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/gorilla/mux"
+	"github.com/pivotal-cf/brokerapi/v8/auth"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/pivotal-cf/brokerapi/v8/middlewares"
+)
+
+func NewWithOptions(serviceBroker domain.ServiceBroker, logger lager.Logger, opts ...Option) http.Handler {
+	cfg := newDefaultConfig(logger)
+	WithOptions(append(opts, withDefaultMiddleware())...)(cfg)
+	attachRoutes(cfg.router, serviceBroker, logger)
+
+	return cfg.router
+}
+
+type Option func(*config)
+
+func WithRouter(router *mux.Router) Option {
+	return func(c *config) {
+		c.router = router
+		c.customRouter = true
+	}
+}
+
+func WithBrokerCredentials(brokerCredentials BrokerCredentials) Option {
+	return func(c *config) {
+		c.router.Use(auth.NewWrapper(brokerCredentials.Username, brokerCredentials.Password).Wrap)
+	}
+}
+
+func WithCustomAuth(authMiddleware mux.MiddlewareFunc) Option {
+	return func(c *config) {
+		c.router.Use(authMiddleware)
+	}
+}
+
+func withDefaultMiddleware() Option {
+	return func(c *config) {
+		if !c.customRouter {
+			c.router.Use(middlewares.APIVersionMiddleware{LoggerFactory: c.logger}.ValidateAPIVersionHdr)
+			c.router.Use(middlewares.AddCorrelationIDToContext)
+			c.router.Use(middlewares.AddOriginatingIdentityToContext)
+			c.router.Use(middlewares.AddInfoLocationToContext)
+			c.router.Use(middlewares.AddRequestIdentityToContext)
+		}
+	}
+}
+
+func WithOptions(opts ...Option) Option {
+	return func(c *config) {
+		for _, o := range opts {
+			o(c)
+		}
+	}
+}
+
+func newDefaultConfig(logger lager.Logger) *config {
+	return &config{
+		router:       mux.NewRouter(),
+		customRouter: false,
+		logger:       logger,
+	}
+}
+
+type config struct {
+	router       *mux.Router
+	customRouter bool
+	logger       lager.Logger
+}

--- a/api_test.go
+++ b/api_test.go
@@ -235,22 +235,22 @@ var _ = Describe("Service Broker API", func() {
 
 			It("returns 401 when the authorization header has an incorrect password", func() {
 				response := makeRequestWithBasicAuth("username", "fake_password")
-				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnauthorized))
 			})
 
 			It("returns 401 when the authorization header has an incorrect username", func() {
 				response := makeRequestWithBasicAuth("fake_username", "password")
-				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnauthorized))
 			})
 
 			It("returns 401 when there is no authorization header", func() {
 				response := makeRequestWithoutAuth()
-				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnauthorized))
 			})
 
 			It("returns 401 when there is an unrecognized authorization header", func() {
 				response := makeRequestWithUnrecognizedAuth()
-				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnauthorized))
 			})
 
 			It("does not call through to the service broker when not authenticated", func() {
@@ -328,7 +328,7 @@ var _ = Describe("Service Broker API", func() {
 
 			It("returns 401 when the authorization header has an incorrect bearer token", func() {
 				response := makeRequestWithBearerTokenAuth("incorrect_token")
-				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnauthorized))
 			})
 
 			It("does not call through to the service broker when not authenticated", func() {
@@ -802,7 +802,7 @@ var _ = Describe("Service Broker API", func() {
 			Context("when the instance does not exist", func() {
 				It("returns a 201 with empty JSON", func() {
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-					Expect(response.StatusCode).To(Equal(http.StatusCreated))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 					Expect(response.Body).To(MatchJSON(fixture("provisioning.json")))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 				})
@@ -828,7 +828,7 @@ var _ = Describe("Service Broker API", func() {
 					It("returns a 500 with error", func() {
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 						Expect(response.Body).To(MatchJSON(fixture("instance_limit_error.json")))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					})
@@ -848,7 +848,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("returns a 500 with error", func() {
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 						Expect(response.Body).To(MatchJSON(`{"description":"broker failed"}`))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					})
@@ -871,7 +871,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("returns status teapot with error", func() {
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-						Expect(response.StatusCode).To(Equal(http.StatusTeapot))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusTeapot))
 						Expect(response.Body).To(MatchJSON(`{"description":"I failed in unique and interesting ways"}`))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					})
@@ -890,7 +890,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("returns a 422", func() {
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-						Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 						Expect(response.Body).To(MatchJSON(`{"description":"The format of the parameters is not valid JSON"}`))
 					})
@@ -945,7 +945,7 @@ var _ = Describe("Service Broker API", func() {
 				Context("returns a StatusOK on", func() {
 					It("sync broker response", func() {
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					})
 
@@ -957,7 +957,7 @@ var _ = Describe("Service Broker API", func() {
 						brokerAPI = brokerapi.New(fakeAsyncServiceBroker, brokerLogger, credentials)
 
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					})
 				})
@@ -970,7 +970,7 @@ var _ = Describe("Service Broker API", func() {
 						provisionDetails["space_guid"] = "space_guid"
 					}()
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-					Expect(response.StatusCode).To(Equal(http.StatusConflict))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusConflict))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 				})
 
@@ -1032,7 +1032,7 @@ var _ = Describe("Service Broker API", func() {
 
 						It("returns a 202", func() {
 							response := makeInstanceProvisioningRequestWithAcceptsIncomplete(instanceID, provisionDetails, true)
-							Expect(response.StatusCode).To(Equal(http.StatusAccepted))
+							Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusAccepted))
 						})
 					})
 
@@ -1054,7 +1054,7 @@ var _ = Describe("Service Broker API", func() {
 
 						It("returns a 201", func() {
 							response := makeInstanceProvisioningRequestWithAcceptsIncomplete(instanceID, provisionDetails, true)
-							Expect(response.StatusCode).To(Equal(http.StatusCreated))
+							Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 						})
 					})
 				})
@@ -1062,7 +1062,7 @@ var _ = Describe("Service Broker API", func() {
 				Context("when the accepts_incomplete flag is false", func() {
 					It("returns a 201", func() {
 						response := makeInstanceProvisioningRequestWithAcceptsIncomplete(instanceID, provisionDetails, false)
-						Expect(response.StatusCode).To(Equal(http.StatusCreated))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 					})
 
 					Context("when broker can only respond asynchronously", func() {
@@ -1083,7 +1083,7 @@ var _ = Describe("Service Broker API", func() {
 						It("returns a 422", func() {
 							acceptsIncomplete := false
 							response := makeInstanceProvisioningRequestWithAcceptsIncomplete(instanceID, provisionDetails, acceptsIncomplete)
-							Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+							Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 							Expect(response.Body).To(MatchJSON(fixture("async_required.json")))
 						})
 					})
@@ -1092,7 +1092,7 @@ var _ = Describe("Service Broker API", func() {
 				Context("when the accepts_incomplete flag is missing", func() {
 					It("returns a 201", func() {
 						response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
-						Expect(response.StatusCode).To(Equal(http.StatusCreated))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 					})
 
 					Context("when broker can only respond asynchronously", func() {
@@ -1113,7 +1113,7 @@ var _ = Describe("Service Broker API", func() {
 						It("returns a 422", func() {
 							acceptsIncomplete := false
 							response := makeInstanceProvisioningRequestWithAcceptsIncomplete(instanceID, provisionDetails, acceptsIncomplete)
-							Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+							Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 							Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 							Expect(response.Body).To(MatchJSON(fixture("async_required.json")))
 						})
@@ -1127,7 +1127,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -1138,7 +1138,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -1149,7 +1149,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".provision.service-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("service_id missing"))
@@ -1160,7 +1160,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".provision.plan-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("plan_id missing"))
@@ -1171,7 +1171,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".provision.invalid-service-id"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("service-id not in the catalog"))
@@ -1182,7 +1182,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceProvisioningRequest(instanceID, provisionDetails, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".provision.invalid-plan-id"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("plan-id not in the catalog"))
@@ -1257,7 +1257,7 @@ var _ = Describe("Service Broker API", func() {
 					instanceID := "instance-id"
 					response := makeInstanceUpdateRequest(instanceID, details, queryString, "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -1267,7 +1267,7 @@ var _ = Describe("Service Broker API", func() {
 					instanceID := "instance-id"
 					response := makeInstanceUpdateRequest(instanceID, details, queryString, "1.14")
 
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -1278,7 +1278,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeInstanceUpdateRequest("instance-id", details, queryString, "2.14")
 
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".update.service-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("service_id missing"))
@@ -1288,7 +1288,7 @@ var _ = Describe("Service Broker API", func() {
 			Context("when the broker returns no error", func() {
 				Context("when the broker responds synchronously", func() {
 					It("returns HTTP 200", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.RawResponse.Header.Get("Content-Type")).To(Equal("application/json"))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 						Expect(response.Body).To(Equal("{}\n"))
@@ -1353,7 +1353,7 @@ var _ = Describe("Service Broker API", func() {
 					})
 
 					It("returns HTTP 202", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusAccepted))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusAccepted))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 					})
 
@@ -1387,7 +1387,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("returns HTTP 422 with error", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 
 					var body map[string]string
@@ -1404,7 +1404,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("returns HTTP 422 with error", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 
 					var body map[string]string
@@ -1421,7 +1421,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("returns HTTP 500", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(updateRequestIdentity))
 
 					var body map[string]string
@@ -1575,7 +1575,7 @@ var _ = Describe("Service Broker API", func() {
 				It("returns a 410", func() {
 					response := makeInstanceDeprovisioningRequest(uniqueInstanceID(), "")
 
-					Expect(response.StatusCode).To(Equal(http.StatusGone))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusGone))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(response.Body).To(MatchJSON(`{}`))
 				})
@@ -1610,7 +1610,7 @@ var _ = Describe("Service Broker API", func() {
 					It("returns a 500 with error", func() {
 						response := makeInstanceDeprovisioningRequest(instanceID, "")
 
-						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 						Expect(response.Body).To(MatchJSON(`{"description":"broker failed"}`))
 					})
@@ -1634,7 +1634,7 @@ var _ = Describe("Service Broker API", func() {
 					It("returns status teapot with error", func() {
 						response := makeInstanceDeprovisioningRequest(instanceID, "")
 
-						Expect(response.StatusCode).To(Equal(http.StatusTeapot))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusTeapot))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 						Expect(response.Body).To(MatchJSON(`{"description":"I failed in unique and interesting ways"}`))
 					})
@@ -1651,7 +1651,7 @@ var _ = Describe("Service Broker API", func() {
 				It("missing header X-Broker-API-Version", func() {
 					apiVersion = ""
 					response := makeInstanceDeprovisioningRequestFull("instance-id", "service-id", "plan-id", "")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -1660,7 +1660,7 @@ var _ = Describe("Service Broker API", func() {
 				It("has wrong version of API", func() {
 					apiVersion = "1.1"
 					response := makeInstanceDeprovisioningRequestFull("instance-id", "service-id", "plan-id", "")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -1668,7 +1668,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("missing service-id", func() {
 					response := makeInstanceDeprovisioningRequestFull("instance-id", "", "plan-id", "")
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".deprovision.service-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("service_id missing"))
@@ -1676,7 +1676,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("missing plan-id", func() {
 					response := makeInstanceDeprovisioningRequestFull("instance-id", "service-id", "", "")
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".deprovision.plan-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("plan_id missing"))
@@ -1690,7 +1690,7 @@ var _ = Describe("Service Broker API", func() {
 
 				response := makeGetInstanceRequest("instance-id")
 
-				Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 				Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 				Expect(lastLogLine().Message).To(ContainSubstring("broker-api.getInstance.fire"))
 				Expect(lastLogLine().Data["error"]).To(ContainSubstring("some error"))
@@ -1701,7 +1701,7 @@ var _ = Describe("Service Broker API", func() {
 
 				response := makeGetInstanceRequest("instance-id")
 
-				Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 				Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 				Expect(lastLogLine().Message).To(ContainSubstring("broker-api.getInstance.unknown-error"))
 				Expect(lastLogLine().Data["error"]).To(ContainSubstring("failed to get instance"))
@@ -1711,7 +1711,7 @@ var _ = Describe("Service Broker API", func() {
 				It("missing header X-Broker-API-Version", func() {
 					apiVersion = ""
 					response := makeGetInstanceRequest("instance-id")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -1720,7 +1720,7 @@ var _ = Describe("Service Broker API", func() {
 				It("has wrong version of API", func() {
 					apiVersion = "1.1"
 					response := makeGetInstanceRequest("instance-id")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -1729,7 +1729,7 @@ var _ = Describe("Service Broker API", func() {
 				It("is using api version < 2.14", func() {
 					apiVersion = "2.13"
 					response := makeGetInstanceRequest("instance-id")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 
 					Expect(lastLogLine().Message).To(ContainSubstring("broker-api.getInstance.broker-api-version-invalid"))
@@ -1738,7 +1738,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("missing instance-id", func() {
 					response := makeGetInstanceRequest("")
-					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusNotFound))
 				})
 			})
 
@@ -1746,7 +1746,7 @@ var _ = Describe("Service Broker API", func() {
 				It("returns 200 when service_id and plan_id are not provided", func() {
 					response := makeGetInstanceWithQueryParamsRequest("instance-id", map[string]string{})
 
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 					Expect(fakeServiceBroker.InstanceFetchDetails.ServiceID).To(Equal(""))
 					Expect(fakeServiceBroker.InstanceFetchDetails.PlanID).To(Equal(""))
 				})
@@ -1759,7 +1759,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeGetInstanceWithQueryParamsRequest("instance-id", params)
 
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 					Expect(fakeServiceBroker.InstanceFetchDetails.ServiceID).To(Equal(params["service_id"]))
 					Expect(fakeServiceBroker.InstanceFetchDetails.PlanID).To(Equal(params["plan_id"]))
 				})
@@ -1771,7 +1771,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeGetInstanceWithQueryParamsRequest("instance-id", params)
 
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 					Expect(fakeServiceBroker.InstanceFetchDetails.ServiceID).To(Equal(params["service_id"]))
 					Expect(fakeServiceBroker.InstanceFetchDetails.PlanID).To(Equal(""))
 				})
@@ -1783,7 +1783,7 @@ var _ = Describe("Service Broker API", func() {
 
 					response := makeGetInstanceWithQueryParamsRequest("instance-id", params)
 
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 					Expect(fakeServiceBroker.InstanceFetchDetails.ServiceID).To(Equal(""))
 					Expect(fakeServiceBroker.InstanceFetchDetails.PlanID).To(Equal(params["plan_id"]))
 				})
@@ -1943,7 +1943,7 @@ var _ = Describe("Service Broker API", func() {
 				It("returns a 201 with body", func() {
 					response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
 
-					Expect(response.StatusCode).To(Equal(http.StatusCreated))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(response.Body).To(MatchJSON(fixture("binding.json")))
 				})
@@ -2009,7 +2009,7 @@ var _ = Describe("Service Broker API", func() {
 				Context("when no bind details are being passed", func() {
 					It("returns a 422", func() {
 						response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), nil)
-						Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					})
 				})
@@ -2115,7 +2115,7 @@ var _ = Describe("Service Broker API", func() {
 						Expect(fakeServiceBroker.BoundBindings[bindingID].BindResource).NotTo(BeNil())
 						Expect(fakeServiceBroker.BoundBindings[bindingID].BindResource.BackupAgent).To(BeTrue())
 
-						Expect(response.StatusCode).To(Equal(http.StatusCreated))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 						Expect(response.Body).To(MatchJSON(`{"backup_agent_url":"http://backup.example.com"}`))
 					})
@@ -2131,7 +2131,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns a 404 with error", func() {
 					response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
-					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusNotFound))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description":"instance does not exist"}`))
 				})
@@ -2163,7 +2163,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("sync broker response", func() {
 						response := makeBindingRequest(instanceID, bindingID, details)
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					})
 
@@ -2174,14 +2174,14 @@ var _ = Describe("Service Broker API", func() {
 						brokerAPI = brokerapi.New(fakeAsyncServiceBroker, brokerLogger, credentials)
 
 						response := makeAsyncBindingRequest(instanceID, bindingID, details)
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					})
 				})
 
 				It("returns a statusConflict", func() {
 					response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
-					Expect(response.StatusCode).To(Equal(http.StatusConflict))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusConflict))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 				})
 
@@ -2207,7 +2207,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns a generic 500 error response", func() {
 					response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
-					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description":"unknown error"}`))
 				})
@@ -2231,7 +2231,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns status teapot and error", func() {
 					response := makeBindingRequest(uniqueInstanceID(), uniqueBindingID(), details)
-					Expect(response.StatusCode).To(Equal(http.StatusTeapot))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusTeapot))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description":"I failed in unique and interesting ways"}`))
 				})
@@ -2258,14 +2258,14 @@ var _ = Describe("Service Broker API", func() {
 				When("the api version is < 2.14", func() {
 					It("successfully returns a sync binding response", func() {
 						response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.13", true)
-						Expect(response.StatusCode).To(Equal(http.StatusCreated))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 						Expect(response.Body).To(MatchJSON(fixture("binding.json")))
 					})
 
 					It("fails for GetBinding request", func() {
 						response := makeGetBindingRequestWithSpecificAPIVersion(instanceID, bindingID, "1.13")
-						Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					})
 				})
@@ -2273,7 +2273,7 @@ var _ = Describe("Service Broker API", func() {
 				When("the api version is 2.14", func() {
 					It("returns an appropriate status code and operation data", func() {
 						response := makeAsyncBindingRequest(instanceID, bindingID, details)
-						Expect(response.StatusCode).To(Equal(http.StatusAccepted))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusAccepted))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 						Expect(response.Body).To(MatchJSON(fixture("async_bind_response.json")))
 					})
@@ -2282,14 +2282,14 @@ var _ = Describe("Service Broker API", func() {
 						fakeAsyncServiceBroker.LastOperationState = "succeeded"
 						fakeAsyncServiceBroker.LastOperationDescription = "some description"
 						response := makeLastBindingOperationRequest(instanceID, bindingID)
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 						Expect(response.Body).To(MatchJSON(fixture("last_operation_succeeded.json")))
 					})
 
 					It("returns the binding for the async request on getBinding", func() {
 						response := makeGetBindingRequestWithSpecificAPIVersion(instanceID, bindingID, "2.14")
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 						Expect(response.Body).To(MatchJSON(fixture("binding.json")))
 					})
@@ -2303,7 +2303,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("missing header X-Broker-API-Version", func() {
 					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "", false)
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -2311,7 +2311,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("has wrong version of API", func() {
 					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "1.14", false)
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -2319,7 +2319,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("missing service-id", func() {
 					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"plan_id": "123"}, "2.14", false)
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.service-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("service_id missing"))
@@ -2327,7 +2327,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("missing plan-id", func() {
 					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"service_id": "123"}, "2.14", false)
-					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring(".bind.plan-id-missing"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("plan_id missing"))
@@ -2384,7 +2384,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("missing header X-Broker-API-Version", func() {
 						response := makeUnbindingRequestWithServiceIDPlanID(instanceID, bindingID, "service-id", "plan-id", "")
-						Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 						Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 						Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -2392,7 +2392,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("has wrong version of API", func() {
 						response := makeUnbindingRequestWithServiceIDPlanID(instanceID, bindingID, "service-id", "plan-id", "1.1")
-						Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 						Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 						Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -2400,7 +2400,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("missing service-id", func() {
 						response := makeUnbindingRequestWithServiceIDPlanID(instanceID, bindingID, "", "plan-id", "2.13")
-						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 						Expect(lastLogLine().Message).To(ContainSubstring(".unbind.service-id-missing"))
 						Expect(lastLogLine().Data["error"]).To(ContainSubstring("service_id missing"))
@@ -2408,7 +2408,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("missing plan-id", func() {
 						response := makeUnbindingRequestWithServiceIDPlanID(instanceID, bindingID, "service-id", "", "2.13")
-						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusBadRequest))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 						Expect(lastLogLine().Message).To(ContainSubstring(".unbind.plan-id-missing"))
 						Expect(lastLogLine().Data["error"]).To(ContainSubstring("plan_id missing"))
@@ -2427,7 +2427,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("returns a 200", func() {
 						response := makeUnbindingRequest(instanceID, bindingID)
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 						Expect(response.Body).To(MatchJSON(`{}`))
 					})
@@ -2446,7 +2446,7 @@ var _ = Describe("Service Broker API", func() {
 				Context("but the binding does not exist", func() {
 					It("returns a 410", func() {
 						response := makeUnbindingRequest(instanceID, "does-not-exist")
-						Expect(response.StatusCode).To(Equal(http.StatusGone))
+						Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusGone))
 						Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 						Expect(response.Body).To(MatchJSON(`{}`))
 					})
@@ -2465,7 +2465,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns a 410", func() {
 					response := makeUnbindingRequest(uniqueInstanceID(), uniqueBindingID())
-					Expect(response.StatusCode).To(Equal(http.StatusGone))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusGone))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 					Expect(response.Body).To(MatchJSON(`{}`))
 				})
@@ -2486,7 +2486,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns a generic 500 error response", func() {
 					response := makeUnbindingRequest(uniqueInstanceID(), uniqueBindingID())
-					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description":"unknown error"}`))
 				})
@@ -2510,7 +2510,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns status teapot with error", func() {
 					response := makeUnbindingRequest(uniqueInstanceID(), uniqueBindingID())
-					Expect(response.StatusCode).To(Equal(http.StatusTeapot))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusTeapot))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(unbindRequestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description":"I failed in unique and interesting ways"}`))
 				})
@@ -2573,7 +2573,7 @@ var _ = Describe("Service Broker API", func() {
 				Expect(logs[1].Data["instance-id"]).To(ContainSubstring(instanceID))
 				Expect(logs[1].Data["state"]).To(ContainSubstring(string(fakeServiceBroker.LastOperationState)))
 
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 				Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 				Expect(response.Body).To(MatchJSON(fixture("last_operation_succeeded.json")))
 			})
@@ -2586,7 +2586,7 @@ var _ = Describe("Service Broker API", func() {
 				Expect(lastLogLine().Message).To(ContainSubstring(".lastOperation.instance-missing"))
 				Expect(lastLogLine().Data["error"]).To(ContainSubstring("instance does not exist"))
 
-				Expect(response.StatusCode).To(Equal(http.StatusGone))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusGone))
 				Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 				Expect(response.Body).To(MatchJSON(`{}`))
 			})
@@ -2599,7 +2599,7 @@ var _ = Describe("Service Broker API", func() {
 				It("returns a generic 500 error response", func() {
 					response := makeLastOperationRequest("instanceID", "", "2.14")
 
-					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description": "unknown error"}`))
 				})
@@ -2623,7 +2623,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("returns status teapot with error", func() {
 					response := makeLastOperationRequest("instanceID", "", "2.14")
-					Expect(response.StatusCode).To(Equal(http.StatusTeapot))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusTeapot))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(response.Body).To(MatchJSON(`{"description":"I failed in unique and interesting ways"}`))
 				})
@@ -2638,7 +2638,7 @@ var _ = Describe("Service Broker API", func() {
 			Context("the request is malformed", func() {
 				It("missing header X-Broker-API-Version", func() {
 					response := makeLastOperationRequest("instance-id", "", "")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header not set"))
@@ -2646,7 +2646,7 @@ var _ = Describe("Service Broker API", func() {
 
 				It("has wrong version of API", func() {
 					response := makeLastOperationRequest("instance-id", "", "1.2")
-					Expect(response.StatusCode).To(Equal(http.StatusPreconditionFailed))
+					Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(requestIdentity))
 					Expect(lastLogLine().Message).To(ContainSubstring("version-header-check.broker-api-version-invalid"))
 					Expect(lastLogLine().Data["error"]).To(ContainSubstring("X-Broker-API-Version Header must be 2.x"))
@@ -2659,7 +2659,7 @@ var _ = Describe("Service Broker API", func() {
 				fakeServiceBroker.GetBindingError = errors.New("something failed")
 
 				response := makeGetBindingRequestWithSpecificAPIVersion("some-instance", "some-binding", "2.14")
-				Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusInternalServerError))
 				Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 				Expect(lastLogLine().Message).To(ContainSubstring("broker-api.getBinding.unknown-error"))
 				Expect(lastLogLine().Data["error"]).To(ContainSubstring("something failed"))
@@ -2669,7 +2669,7 @@ var _ = Describe("Service Broker API", func() {
 				fakeServiceBroker.GetBindingError = brokerapi.NewFailureResponse(errors.New("some error"), http.StatusUnprocessableEntity, "fire")
 
 				response := makeGetBindingRequestWithSpecificAPIVersion("some-instance", "some-binding", "2.14")
-				Expect(response.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 				Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 				Expect(lastLogLine().Message).To(ContainSubstring("broker-api.getBinding.fire"))
 				Expect(lastLogLine().Data["error"]).To(ContainSubstring("some error"))
@@ -2680,7 +2680,7 @@ var _ = Describe("Service Broker API", func() {
 			It("returns 200 when service_id and plan_id are not provided", func() {
 				response := makeGetBindingWithQueryParamsRequest("instance-id", "binding-id", map[string]string{})
 
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 				Expect(fakeServiceBroker.BindingFetchDetails.ServiceID).To(Equal(""))
 				Expect(fakeServiceBroker.BindingFetchDetails.PlanID).To(Equal(""))
 			})
@@ -2693,7 +2693,7 @@ var _ = Describe("Service Broker API", func() {
 
 				response := makeGetBindingWithQueryParamsRequest("instance-id", "binding-id", params)
 
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 				Expect(fakeServiceBroker.BindingFetchDetails.ServiceID).To(Equal(params["service_id"]))
 				Expect(fakeServiceBroker.BindingFetchDetails.PlanID).To(Equal(params["plan_id"]))
 			})
@@ -2705,7 +2705,7 @@ var _ = Describe("Service Broker API", func() {
 
 				response := makeGetBindingWithQueryParamsRequest("instance-id", "binding-id", params)
 
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 				Expect(fakeServiceBroker.BindingFetchDetails.ServiceID).To(Equal(params["service_id"]))
 				Expect(fakeServiceBroker.BindingFetchDetails.PlanID).To(Equal(""))
 			})
@@ -2717,7 +2717,7 @@ var _ = Describe("Service Broker API", func() {
 
 				response := makeGetBindingWithQueryParamsRequest("instance-id", "binding-id", params)
 
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusOK))
 				Expect(fakeServiceBroker.BindingFetchDetails.ServiceID).To(Equal(""))
 				Expect(fakeServiceBroker.BindingFetchDetails.PlanID).To(Equal(params["plan_id"]))
 			})

--- a/api_test.go
+++ b/api_test.go
@@ -2752,5 +2752,22 @@ var _ = Describe("Service Broker API", func() {
 				Expect(fakeServiceBroker.ProvisionedInstances).To(HaveKey(instanceID))
 			})
 		})
+
+		Describe("WithEncodedPath()", func() {
+			const encodedInstanceID = "foo%2Fbar"
+
+			It("does not accept URL-encoded paths by default", func() {
+				brokerAPI = brokerapi.NewWithOptions(fakeServiceBroker, brokerLogger, brokerapi.WithBrokerCredentials(credentials))
+				response := makeInstanceProvisioningRequest(encodedInstanceID, provisionDetails, "")
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusNotFound))
+			})
+
+			It("will accept URL-encoded paths when configured", func() {
+				brokerAPI = brokerapi.NewWithOptions(fakeServiceBroker, brokerLogger, brokerapi.WithEncodedPath(), brokerapi.WithBrokerCredentials(credentials))
+				response := makeInstanceProvisioningRequest(encodedInstanceID, provisionDetails, "")
+				Expect(response.RawResponse).To(HaveHTTPStatus(http.StatusCreated))
+				Expect(fakeServiceBroker.ProvisionedInstances).To(HaveKey(encodedInstanceID))
+			})
+		})
 	})
 })


### PR DESCRIPTION
This is an example of how #177 could be implemented by using the options pattern in the constructor