### PR TITLE
feat!: update import path to v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Go package for building [V2 Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/) compliant Service Brokers.
 
-## [Docs](https://godoc.org/github.com/pivotal-cf/brokerapi/v9)
+## [Docs](https://godoc.org/github.com/pivotal-cf/brokerapi/v10)
 
 ## Dependencies
 
@@ -18,15 +18,15 @@ We appreciate and welcome open source contibution. We will try to review the cha
 ## Usage
 
 `brokerapi` defines a
-[`ServiceBroker`](https://godoc.org/github.com/pivotal-cf/brokerapi/v9#ServiceBroker)
+[`ServiceBroker`](https://godoc.org/github.com/pivotal-cf/brokerapi/v10#ServiceBroker)
 interface. Pass an implementation of this to
-[`brokerapi.New`](https://godoc.org/github.com/pivotal-cf/brokerapi/v9#New)
-or [`brokerapi.NewWithOptions`](https://pkg.go.dev/github.com/pivotal-cf/brokerapi/v9#NewWithOptions),
+[`brokerapi.New`](https://godoc.org/github.com/pivotal-cf/brokerapi/v10#New)
+or [`brokerapi.NewWithOptions`](https://pkg.go.dev/github.com/pivotal-cf/brokerapi/v10#NewWithOptions),
 which returns an `http.Handler` that you can use to serve handle HTTP requests.
 
 Alternatively, if you already have a `*chi.Mux` that you want to attach
 service broker routes to, you can use
-[`brokerapi.AttachRoutes`](https://godoc.org/github.com/pivotal-cf/brokerapi/v9#AttachRoutes).
+[`brokerapi.AttachRoutes`](https://godoc.org/github.com/pivotal-cf/brokerapi/v10#AttachRoutes).
 Note in this case, the Basic Authentication and Originating Identity middleware
 will not be set up, so you will have to attach them manually if required.
 

--- a/api.go
+++ b/api.go
@@ -20,7 +20,7 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/handlers"
+	"github.com/pivotal-cf/brokerapi/v10/handlers"
 )
 
 type BrokerCredentials struct {

--- a/api_options.go
+++ b/api_options.go
@@ -20,9 +20,9 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/auth"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/auth"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
 )
 
 type middlewareFunc func(http.Handler) http.Handler

--- a/api_test.go
+++ b/api_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9"
-	"github.com/pivotal-cf/brokerapi/v9/fakes"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v10/fakes"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
 )
 
 var _ = Describe("Service Broker API", func() {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/pivotal-cf/brokerapi/v9/auth"
+	"github.com/pivotal-cf/brokerapi/v10/auth"
 )
 
 var _ = Describe("Auth Wrapper", func() {

--- a/catalog.go
+++ b/catalog.go
@@ -18,7 +18,7 @@ package brokerapi
 import (
 	"reflect"
 
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9"
+	"github.com/pivotal-cf/brokerapi/v10"
 )
 
 var _ = Describe("Catalog", func() {

--- a/context_utils.go
+++ b/context_utils.go
@@ -3,7 +3,7 @@ package brokerapi
 import (
 	"context"
 
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 func AddServiceToContext(ctx context.Context, service *Service) context.Context {

--- a/context_utils_test.go
+++ b/context_utils_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/pivotal-cf/brokerapi/v9"
+	"github.com/pivotal-cf/brokerapi/v10"
 )
 
 var _ = Describe("Context Utilities", func() {

--- a/domain/apiresponses/failure_responses_test.go
+++ b/domain/apiresponses/failure_responses_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/onsi/gomega/gbytes"

--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -15,7 +15,7 @@
 
 package apiresponses
 
-import "github.com/pivotal-cf/brokerapi/v9/domain"
+import "github.com/pivotal-cf/brokerapi/v10/domain"
 
 type EmptyResponse struct{}
 

--- a/domain/apiresponses/responses_test.go
+++ b/domain/apiresponses/responses_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
 )
 
 var _ = Describe("Catalog Response", func() {

--- a/domain/maintenance_info_test.go
+++ b/domain/maintenance_info_test.go
@@ -3,7 +3,7 @@ package domain_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 var _ = Describe("MaintenanceInfo", func() {

--- a/domain/service_catalog_test.go
+++ b/domain/service_catalog_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 var maximumPollingDuration = 3600

--- a/domain/service_metadata_test.go
+++ b/domain/service_metadata_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 var _ = Describe("ServiceMetadata", func() {

--- a/domain/service_plan_metadata_test.go
+++ b/domain/service_plan_metadata_test.go
@@ -7,8 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 var _ = Describe("ServicePlanMetadata", func() {

--- a/failure_response.go
+++ b/failure_response.go
@@ -7,7 +7,7 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain/apiresponses

--- a/failure_response_test.go
+++ b/failure_response_test.go
@@ -16,7 +16,7 @@
 package brokerapi_test
 
 import (
-	"github.com/pivotal-cf/brokerapi/v9"
+	"github.com/pivotal-cf/brokerapi/v10"
 
 	"errors"
 

--- a/fakes/auto_fake_service_broker.go
+++ b/fakes/auto_fake_service_broker.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 type AutoFakeServiceBroker struct {

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/pivotal-cf/brokerapi/v9"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
 )
 
 type FakeServiceBroker struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pivotal-cf/brokerapi/v9
+module github.com/pivotal-cf/brokerapi/v10
 
 go 1.19
 

--- a/handlers/api_handler.go
+++ b/handlers/api_handler.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 const (

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -7,10 +7,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const (

--- a/handlers/catalog.go
+++ b/handlers/catalog.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const getCatalogLogKey = "getCatalog"

--- a/handlers/catalog_test.go
+++ b/handlers/catalog_test.go
@@ -9,12 +9,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	brokerFakes "github.com/pivotal-cf/brokerapi/v9/fakes"
-	"github.com/pivotal-cf/brokerapi/v9/handlers"
-	"github.com/pivotal-cf/brokerapi/v9/handlers/fakes"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	brokerFakes "github.com/pivotal-cf/brokerapi/v10/fakes"
+	"github.com/pivotal-cf/brokerapi/v10/handlers"
+	"github.com/pivotal-cf/brokerapi/v10/handlers/fakes"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
 )
 
 var _ = Describe("Services", func() {

--- a/handlers/deprovision.go
+++ b/handlers/deprovision.go
@@ -6,10 +6,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const deprovisionLogKey = "deprovision"

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -7,10 +7,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const getBindLogKey = "getBinding"

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -7,10 +7,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const getInstanceLogKey = "getInstance"

--- a/handlers/last_binding_operation.go
+++ b/handlers/last_binding_operation.go
@@ -7,10 +7,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const lastBindingOperationLogKey = "lastBindingOperation"

--- a/handlers/last_binding_operation_test.go
+++ b/handlers/last_binding_operation_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	brokerFakes "github.com/pivotal-cf/brokerapi/v9/fakes"
-	"github.com/pivotal-cf/brokerapi/v9/handlers"
-	"github.com/pivotal-cf/brokerapi/v9/handlers/fakes"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	brokerFakes "github.com/pivotal-cf/brokerapi/v10/fakes"
+	"github.com/pivotal-cf/brokerapi/v10/handlers"
+	"github.com/pivotal-cf/brokerapi/v10/handlers/fakes"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
 	"github.com/pkg/errors"
 )
 

--- a/handlers/last_operation.go
+++ b/handlers/last_operation.go
@@ -6,10 +6,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const lastOperationLogKey = "lastOperation"

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -7,10 +7,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const (

--- a/handlers/unbind.go
+++ b/handlers/unbind.go
@@ -6,10 +6,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const unbindLogKey = "unbind"

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -8,10 +8,10 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 const updateLogKey = "update"

--- a/maintenance_info.go
+++ b/maintenance_info.go
@@ -1,7 +1,7 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v9/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain

--- a/maintenance_info_test.go
+++ b/maintenance_info_test.go
@@ -3,7 +3,7 @@ package brokerapi_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9"
+	"github.com/pivotal-cf/brokerapi/v10"
 )
 
 var _ = Describe("MaintenanceInfo", func() {

--- a/response.go
+++ b/response.go
@@ -16,8 +16,8 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain/apiresponses

--- a/response_test.go
+++ b/response_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9"
+	"github.com/pivotal-cf/brokerapi/v10"
 )
 
 var _ = Describe("Catalog Response", func() {

--- a/service_broker.go
+++ b/service_broker.go
@@ -16,8 +16,8 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/utils/context.go
+++ b/utils/context.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
 )
 
 type contextKey string

--- a/utils/context_test.go
+++ b/utils/context_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v9/domain"
-	"github.com/pivotal-cf/brokerapi/v9/middlewares"
-	"github.com/pivotal-cf/brokerapi/v9/utils"
+	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v10/utils"
 )
 
 var _ = Describe("Context", func() {


### PR DESCRIPTION
As we plan for v10, we need to update the import path

This was done using the excellent
[gomajor](https://pkg.go.dev/github.com/icholy/gomajor) tool, specifically:
```
gomajor path -next
```