### PR TITLE
fix: AttachRoutes() and WithRouter() should accept chi.Router

### DIFF
--- a/api.go
+++ b/api.go
@@ -36,11 +36,11 @@ func NewWithCustomAuth(serviceBroker ServiceBroker, logger lager.Logger, authMid
 	return NewWithOptions(serviceBroker, logger, WithCustomAuth(authMiddleware))
 }
 
-func AttachRoutes(router *chi.Mux, serviceBroker ServiceBroker, logger lager.Logger) {
+func AttachRoutes(router chi.Router, serviceBroker ServiceBroker, logger lager.Logger) {
 	attachRoutes(router, serviceBroker, logger)
 }
 
-func attachRoutes(router *chi.Mux, serviceBroker ServiceBroker, logger lager.Logger) {
+func attachRoutes(router chi.Router, serviceBroker ServiceBroker, logger lager.Logger) {
 	apiHandler := handlers.NewApiHandler(serviceBroker, logger)
 	router.Get("/v2/catalog", apiHandler.Catalog)
 

--- a/api_options.go
+++ b/api_options.go
@@ -37,7 +37,7 @@ func NewWithOptions(serviceBroker domain.ServiceBroker, logger lager.Logger, opt
 
 type Option func(*config)
 
-func WithRouter(router *chi.Mux) Option {
+func WithRouter(router chi.Router) Option {
 	return func(c *config) {
 		c.router = router
 		c.customRouter = true
@@ -96,7 +96,7 @@ func newDefaultConfig(logger lager.Logger) *config {
 }
 
 type config struct {
-	router       *chi.Mux
+	router       chi.Router
 	customRouter bool
 	logger       lager.Logger
 }


### PR DESCRIPTION
The chi.Router interface should be accepted rather than the *chi.Mux contete type. This allows for the contrete type to be substututed in accordance with the [Liskov substitution
principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle).

Resolves https://github.com/pivotal-cf/brokerapi/issues/253