### PR TITLE
chore: limit support of Go versions to 1.20 & 1.21

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.19', '1.20' ]
+        version: [ '1.20', '1.21' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal-cf/brokerapi/v10
 
-go 1.19
+go 1.21
 
 require (
 	code.cloudfoundry.org/lager/v3 v3.0.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal-cf/brokerapi/v10
 
-go 1.21
+go 1.20
 
 require (
 	code.cloudfoundry.org/lager/v3 v3.0.2


### PR DESCRIPTION
[#185100152](https://www.pivotaltracker.com/story/show/185100152)