### PR TITLE
chore: automate go version upgrade

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,17 +13,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [ '1.20', '1.21' ]
-    name: Go ${{ matrix.version }}
+    name: Go test
     outputs:
       pr_number: ${{ github.event.number }}
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.version }}
-    - uses: actions/checkout@v2
+        go-version: '1.21.4'
+    - uses: actions/checkout@v4
     - run: make test
   call-dependabot-pr-workflow:
     needs: test


### PR DESCRIPTION
We use the latest version of Golang for executing the tests.
We change the structure of the Makefile and the run-test GitHub action to bump the Golang version automatically in the Makefile, go.mod and GitHub action files.

[#186180915](https://www.pivotaltracker.com/story/show/186180915)