### PR TITLE
test: using stable/oldstable aliases

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,10 +20,10 @@ jobs:
     outputs:
       pr_number: ${{ github.event.number }}
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: make test
   call-dependabot-pr-workflow:
     needs: test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.20', '1.21' ]
+        version: [ 'stable', 'oldstable', '1.20' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
If stable is provided, action will get the latest stable version from the go-versions repository manifest.

If oldstable is provided, when current release is 1.19.x, action will resolve version as 1.18.x, where x is the latest patch release.

We also want to maintain 1.20 version, so we test it.

[#186180915](https://www.pivotaltracker.com/story/show/186180915)