### PR TITLE
feat!: update import path to v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Go package for building [V2 Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/) compliant Service Brokers.
 
-## [Docs](https://godoc.org/github.com/pivotal-cf/brokerapi/v10)
+## [Docs](https://godoc.org/github.com/pivotal-cf/brokerapi/v11)
 
 ## Dependencies
 
@@ -18,15 +18,15 @@ We appreciate and welcome open source contribution. We will try to review the ch
 ## Usage
 
 `brokerapi` defines a
-[`ServiceBroker`](https://godoc.org/github.com/pivotal-cf/brokerapi/v10#ServiceBroker)
+[`ServiceBroker`](https://godoc.org/github.com/pivotal-cf/brokerapi/v11#ServiceBroker)
 interface. Pass an implementation of this to
-[`brokerapi.New`](https://godoc.org/github.com/pivotal-cf/brokerapi/v10#New)
-or [`brokerapi.NewWithOptions`](https://pkg.go.dev/github.com/pivotal-cf/brokerapi/v10#NewWithOptions),
+[`brokerapi.New`](https://godoc.org/github.com/pivotal-cf/brokerapi/v11#New)
+or [`brokerapi.NewWithOptions`](https://pkg.go.dev/github.com/pivotal-cf/brokerapi/v11#NewWithOptions),
 which returns an `http.Handler` that you can use to serve handle HTTP requests.
 
 Alternatively, if you already have a `*chi.Mux` that you want to attach
 service broker routes to, you can use
-[`brokerapi.AttachRoutes`](https://godoc.org/github.com/pivotal-cf/brokerapi/v10#AttachRoutes).
+[`brokerapi.AttachRoutes`](https://godoc.org/github.com/pivotal-cf/brokerapi/v11#AttachRoutes).
 Note in this case, the Basic Authentication and Originating Identity middleware
 will not be set up, so you will have to attach them manually if required.
 

--- a/api.go
+++ b/api.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/handlers"
+	"github.com/pivotal-cf/brokerapi/v11/handlers"
 )
 
 type BrokerCredentials struct {

--- a/api_options.go
+++ b/api_options.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/auth"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/auth"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 type middlewareFunc func(http.Handler) http.Handler

--- a/api_test.go
+++ b/api_test.go
@@ -32,9 +32,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/pivotal-cf/brokerapi/v10"
-	"github.com/pivotal-cf/brokerapi/v10/fakes"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11"
+	"github.com/pivotal-cf/brokerapi/v11/fakes"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 var _ = Describe("Service Broker API", func() {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/pivotal-cf/brokerapi/v10/auth"
+	"github.com/pivotal-cf/brokerapi/v11/auth"
 )
 
 var _ = Describe("Auth Wrapper", func() {

--- a/catalog.go
+++ b/catalog.go
@@ -18,7 +18,7 @@ package brokerapi
 import (
 	"reflect"
 
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v11"
 )
 
 var _ = Describe("Catalog", func() {

--- a/context_utils.go
+++ b/context_utils.go
@@ -3,7 +3,7 @@ package brokerapi
 import (
 	"context"
 
-	"github.com/pivotal-cf/brokerapi/v10/utils"
+	"github.com/pivotal-cf/brokerapi/v11/utils"
 )
 
 func AddServiceToContext(ctx context.Context, service *Service) context.Context {

--- a/context_utils_test.go
+++ b/context_utils_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v11"
 )
 
 var _ = Describe("Context Utilities", func() {

--- a/domain/apiresponses/failure_responses_test.go
+++ b/domain/apiresponses/failure_responses_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 var _ = Describe("FailureResponse", func() {

--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -15,7 +15,7 @@
 
 package apiresponses
 
-import "github.com/pivotal-cf/brokerapi/v10/domain"
+import "github.com/pivotal-cf/brokerapi/v11/domain"
 
 type EmptyResponse struct{}
 

--- a/domain/apiresponses/responses_test.go
+++ b/domain/apiresponses/responses_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 var _ = Describe("Catalog Response", func() {

--- a/domain/maintenance_info_test.go
+++ b/domain/maintenance_info_test.go
@@ -3,7 +3,7 @@ package domain_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 var _ = Describe("MaintenanceInfo", func() {

--- a/domain/service_catalog_test.go
+++ b/domain/service_catalog_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 var maximumPollingDuration = 3600

--- a/domain/service_metadata_test.go
+++ b/domain/service_metadata_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 var _ = Describe("ServiceMetadata", func() {

--- a/domain/service_plan_metadata_test.go
+++ b/domain/service_plan_metadata_test.go
@@ -7,8 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 var _ = Describe("ServicePlanMetadata", func() {

--- a/failure_response.go
+++ b/failure_response.go
@@ -7,7 +7,7 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain/apiresponses

--- a/failure_response_test.go
+++ b/failure_response_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/pivotal-cf/brokerapi/v10"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 var _ = Describe("FailureResponse", func() {

--- a/fakes/auto_fake_service_broker.go
+++ b/fakes/auto_fake_service_broker.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 type AutoFakeServiceBroker struct {

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/pivotal-cf/brokerapi/v10"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 type FakeServiceBroker struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pivotal-cf/brokerapi/v10
+module github.com/pivotal-cf/brokerapi/v11
 
 go 1.21
 

--- a/handlers/api_handler.go
+++ b/handlers/api_handler.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
 )
 
 const (

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const (

--- a/handlers/catalog.go
+++ b/handlers/catalog.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const getCatalogLogKey = "getCatalog"

--- a/handlers/catalog_test.go
+++ b/handlers/catalog_test.go
@@ -9,12 +9,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	brokerFakes "github.com/pivotal-cf/brokerapi/v10/fakes"
-	"github.com/pivotal-cf/brokerapi/v10/handlers"
-	"github.com/pivotal-cf/brokerapi/v10/handlers/fakes"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	brokerFakes "github.com/pivotal-cf/brokerapi/v11/fakes"
+	"github.com/pivotal-cf/brokerapi/v11/handlers"
+	"github.com/pivotal-cf/brokerapi/v11/handlers/fakes"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 var _ = Describe("Services", func() {

--- a/handlers/deprovision.go
+++ b/handlers/deprovision.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const deprovisionLogKey = "deprovision"

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const getBindLogKey = "getBinding"

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -6,12 +6,12 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const getInstanceLogKey = "getInstance"

--- a/handlers/last_binding_operation.go
+++ b/handlers/last_binding_operation.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const lastBindingOperationLogKey = "lastBindingOperation"

--- a/handlers/last_binding_operation_test.go
+++ b/handlers/last_binding_operation_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	brokerFakes "github.com/pivotal-cf/brokerapi/v10/fakes"
-	"github.com/pivotal-cf/brokerapi/v10/handlers"
-	"github.com/pivotal-cf/brokerapi/v10/handlers/fakes"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	brokerFakes "github.com/pivotal-cf/brokerapi/v11/fakes"
+	"github.com/pivotal-cf/brokerapi/v11/handlers"
+	"github.com/pivotal-cf/brokerapi/v11/handlers/fakes"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 	"github.com/pkg/errors"
 )
 

--- a/handlers/last_operation.go
+++ b/handlers/last_operation.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const lastOperationLogKey = "lastOperation"

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
-	"github.com/pivotal-cf/brokerapi/v10/utils"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/utils"
 )
 
 const (

--- a/handlers/unbind.go
+++ b/handlers/unbind.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const unbindLogKey = "unbind"

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const updateLogKey = "update"

--- a/internal/blog/blog.go
+++ b/internal/blog/blog.go
@@ -13,7 +13,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 const (

--- a/internal/blog/blog_test.go
+++ b/internal/blog/blog_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/pivotal-cf/brokerapi/v10/internal/blog"
-	"github.com/pivotal-cf/brokerapi/v10/middlewares"
+	"github.com/pivotal-cf/brokerapi/v11/internal/blog"
+	"github.com/pivotal-cf/brokerapi/v11/middlewares"
 )
 
 var _ = Describe("Context data", func() {

--- a/maintenance_info.go
+++ b/maintenance_info.go
@@ -1,7 +1,7 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain

--- a/maintenance_info_test.go
+++ b/maintenance_info_test.go
@@ -3,7 +3,7 @@ package brokerapi_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v11"
 )
 
 var _ = Describe("MaintenanceInfo", func() {

--- a/response.go
+++ b/response.go
@@ -16,8 +16,8 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 // Deprecated: Use github.com/pivotal-cf/brokerapi/domain/apiresponses

--- a/response_test.go
+++ b/response_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10"
+	"github.com/pivotal-cf/brokerapi/v11"
 )
 
 var _ = Describe("Catalog Response", func() {

--- a/service_broker.go
+++ b/service_broker.go
@@ -16,8 +16,8 @@
 package brokerapi
 
 import (
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/utils/context.go
+++ b/utils/context.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"context"
 
-	"github.com/pivotal-cf/brokerapi/v10/domain"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 type contextKey string

--- a/utils/context_test.go
+++ b/utils/context_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v10/domain"
-	"github.com/pivotal-cf/brokerapi/v10/utils"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
+	"github.com/pivotal-cf/brokerapi/v11/utils"
 )
 
 var _ = Describe("Context", func() {


### PR DESCRIPTION
As we plan for v11, we need to update the import path

This was done using the excellent
[gomajor](https://pkg.go.dev/github.com/icholy/gomajor) tool, specifically:
```
gomajor path -next
```

The README also had to be updated by a person