### PR TITLE
chore: handle some unhandled errors

### DIFF
--- a/domain/service_metadata.go
+++ b/domain/service_metadata.go
@@ -26,7 +26,9 @@ func (sm ServiceMetadata) MarshalJSON() ([]byte, error) {
 	}
 
 	var m map[string]interface{}
-	json.Unmarshal(b, &m)
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
 	delete(m, additionalMetadataName)
 
 	for k, v := range sm.AdditionalMetadata {

--- a/domain/service_metadata_test.go
+++ b/domain/service_metadata_test.go
@@ -10,20 +10,19 @@ import (
 )
 
 var _ = Describe("ServiceMetadata", func() {
-	Describe("ServiceMetadata", func() {
-		Describe("JSON encoding", func() {
-			It("uses the correct keys", func() {
-				shareable := true
-				metadata := domain.ServiceMetadata{
-					DisplayName:         "Cassandra",
-					LongDescription:     "A long description of Cassandra",
-					DocumentationUrl:    "doc",
-					SupportUrl:          "support",
-					ImageUrl:            "image",
-					ProviderDisplayName: "display",
-					Shareable:           &shareable,
-				}
-				jsonString := `{
+	Describe("JSON encoding", func() {
+		It("uses the correct keys", func() {
+			shareable := true
+			metadata := domain.ServiceMetadata{
+				DisplayName:         "Cassandra",
+				LongDescription:     "A long description of Cassandra",
+				DocumentationUrl:    "doc",
+				SupportUrl:          "support",
+				ImageUrl:            "image",
+				ProviderDisplayName: "display",
+				Shareable:           &shareable,
+			}
+			jsonString := `{
 					"displayName":"Cassandra",
 					"longDescription":"A long description of Cassandra",
 					"documentationUrl":"doc",
@@ -33,83 +32,83 @@ var _ = Describe("ServiceMetadata", func() {
 					"shareable":true
 				}`
 
-				Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
-			})
-
-			It("encodes the AdditionalMetadata fields in the metadata fields", func() {
-				metadata := domain.ServiceMetadata{
-					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
-						"foo": "bar",
-						"baz": 1,
-					},
-				}
-				jsonString := `{
-					"displayName":"name",
-					"foo": "bar",
-					"baz": 1
-				}`
-
-				Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
-
-				By("not mutating the AdditionalMetadata during custom JSON marshalling")
-				Expect(len(metadata.AdditionalMetadata)).To(Equal(2))
-			})
-
-			It("it can marshal same structure in parallel requests", func() {
-				metadata := domain.ServiceMetadata{
-					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
-						"foo": "bar",
-						"baz": 1,
-					},
-				}
-				jsonString := `{
-					"displayName":"name",
-					"foo": "bar",
-					"baz": 1
-				}`
-
-				var wg sync.WaitGroup
-				wg.Add(2)
-
-				for i := 0; i < 2; i++ {
-					go func() {
-						defer wg.Done()
-						defer GinkgoRecover()
-
-						Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
-					}()
-				}
-				wg.Wait()
-			})
-
-			It("returns an error when additional metadata is not marshallable", func() {
-				metadata := domain.ServiceMetadata{
-					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
-						"foo": make(chan int),
-					},
-				}
-				_, err := json.Marshal(metadata)
-				Expect(err).To(MatchError(ContainSubstring("unmarshallable content in AdditionalMetadata")))
-			})
+			Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
 		})
 
-		Describe("JSON decoding", func() {
-			It("sets the AdditionalMetadata from unrecognized fields", func() {
-				metadata := domain.ServiceMetadata{}
-				jsonString := `{"foo":["test"],"bar":"Some display name"}`
+		It("encodes the AdditionalMetadata fields in the metadata fields", func() {
+			metadata := domain.ServiceMetadata{
+				DisplayName: "name",
+				AdditionalMetadata: map[string]interface{}{
+					"foo": "bar",
+					"baz": 1,
+				},
+			}
+			jsonString := `{
+					"displayName":"name",
+					"foo": "bar",
+					"baz": 1
+				}`
 
-				err := json.Unmarshal([]byte(jsonString), &metadata)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
-				Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
-			})
+			Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
 
-			It("does not include convention fields into additional metadata", func() {
-				metadata := domain.ServiceMetadata{}
-				jsonString := `{
+			By("not mutating the AdditionalMetadata during custom JSON marshalling")
+			Expect(len(metadata.AdditionalMetadata)).To(Equal(2))
+		})
+
+		It("it can marshal same structure in parallel requests", func() {
+			metadata := domain.ServiceMetadata{
+				DisplayName: "name",
+				AdditionalMetadata: map[string]interface{}{
+					"foo": "bar",
+					"baz": 1,
+				},
+			}
+			jsonString := `{
+					"displayName":"name",
+					"foo": "bar",
+					"baz": 1
+				}`
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			for i := 0; i < 2; i++ {
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+
+					Expect(json.Marshal(metadata)).To(MatchJSON(jsonString))
+				}()
+			}
+			wg.Wait()
+		})
+
+		It("returns an error when additional metadata is not marshallable", func() {
+			metadata := domain.ServiceMetadata{
+				DisplayName: "name",
+				AdditionalMetadata: map[string]interface{}{
+					"foo": make(chan int),
+				},
+			}
+			_, err := json.Marshal(metadata)
+			Expect(err).To(MatchError(ContainSubstring("unmarshallable content in AdditionalMetadata")))
+		})
+	})
+
+	Describe("JSON decoding", func() {
+		It("sets the AdditionalMetadata from unrecognized fields", func() {
+			metadata := domain.ServiceMetadata{}
+			jsonString := `{"foo":["test"],"bar":"Some display name"}`
+
+			err := json.Unmarshal([]byte(jsonString), &metadata)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+			Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
+		})
+
+		It("does not include convention fields into additional metadata", func() {
+			metadata := domain.ServiceMetadata{}
+			jsonString := `{
 					"displayName":"Cassandra",
 					"longDescription":"A long description of Cassandra",
 					"documentationUrl":"doc",
@@ -118,10 +117,9 @@ var _ = Describe("ServiceMetadata", func() {
 					"providerDisplayName":"display",
 					"shareable":true
 				}`
-				err := json.Unmarshal([]byte(jsonString), &metadata)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(metadata.AdditionalMetadata).To(BeNil())
-			})
+			err := json.Unmarshal([]byte(jsonString), &metadata)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata.AdditionalMetadata).To(BeNil())
 		})
 	})
 })

--- a/domain/service_plan_metadata.go
+++ b/domain/service_plan_metadata.go
@@ -54,7 +54,9 @@ func (spm ServicePlanMetadata) MarshalJSON() ([]byte, error) {
 	}
 
 	var m map[string]interface{}
-	json.Unmarshal(b, &m)
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
 	delete(m, additionalMetadataName)
 
 	for k, v := range spm.AdditionalMetadata {


### PR DESCRIPTION
Some unhandled errors are now handled. Arguably this is not necessary as they are "impossible" errors that cannot occur and are untestable. But code can change over time, and if those errors ever become possible, then it will be better to fail fast rather than to ignore the error.