### PR TITLE
chore: prefer "any" to "interface{}"

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Service Broker API", func() {
 
 	const requestIdentity = "Request Identity Name"
 
-	makeInstanceProvisioningRequest := func(instanceID string, details map[string]interface{}, queryString string) (response *http.Response) {
+	makeInstanceProvisioningRequest := func(instanceID string, details map[string]any, queryString string) (response *http.Response) {
 		withServer(brokerAPI, func(r requester) {
 			path := "/v2/service_instances/" + instanceID + queryString
 
@@ -68,7 +68,7 @@ var _ = Describe("Service Broker API", func() {
 		return response
 	}
 
-	makeInstanceProvisioningRequestWithAcceptsIncomplete := func(instanceID string, details map[string]interface{}, acceptsIncomplete bool) *http.Response {
+	makeInstanceProvisioningRequestWithAcceptsIncomplete := func(instanceID string, details map[string]any, acceptsIncomplete bool) *http.Response {
 		var acceptsIncompleteFlag string
 
 		if acceptsIncomplete {
@@ -676,16 +676,16 @@ var _ = Describe("Service Broker API", func() {
 
 		Describe("provisioning", func() {
 			var instanceID string
-			var provisionDetails map[string]interface{}
+			var provisionDetails map[string]any
 
 			BeforeEach(func() {
 				instanceID = uniqueInstanceID()
-				provisionDetails = map[string]interface{}{
+				provisionDetails = map[string]any{
 					"service_id":        fakeServiceBroker.ServiceID,
 					"plan_id":           "plan-id",
 					"organization_guid": "organization-guid",
 					"space_guid":        "space-guid",
-					"maintenance_info": map[string]interface{}{
+					"maintenance_info": map[string]any{
 						"public": map[string]string{
 							"k8s-version": "0.0.1-alpha2",
 						},
@@ -755,11 +755,11 @@ var _ = Describe("Service Broker API", func() {
 				var rawCtx string
 
 				BeforeEach(func() {
-					provisionDetails["parameters"] = map[string]interface{}{
+					provisionDetails["parameters"] = map[string]any{
 						"string": "some-string",
 						"number": 1,
 						"object": struct{ Name string }{"some-name"},
-						"array":  []interface{}{"a", "b", "c"},
+						"array":  []any{"a", "b", "c"},
 					}
 					rawParams = `{
 					"string":"some-string",
@@ -767,11 +767,11 @@ var _ = Describe("Service Broker API", func() {
 					"object": { "Name": "some-name" },
 					"array": [ "a", "b", "c" ]
 				}`
-					provisionDetails["context"] = map[string]interface{}{
+					provisionDetails["context"] = map[string]any{
 						"platform":      "fake-platform",
 						"serial-number": 12648430,
 						"object":        struct{ Name string }{"parameter"},
-						"array":         []interface{}{"1", "2", "3"},
+						"array":         []any{"1", "2", "3"},
 					}
 					rawCtx = `{
 					"platform":"fake-platform",
@@ -1193,13 +1193,13 @@ var _ = Describe("Service Broker API", func() {
 		Describe("updating", func() {
 			var (
 				instanceID  string
-				details     map[string]interface{}
+				details     map[string]any
 				queryString string
 				response    *http.Response
 			)
 			const updateRequestIdentity = "Update Request Identity Name"
 
-			makeInstanceUpdateRequest := func(instanceID string, details map[string]interface{}, queryString string, apiVersion string) (response *http.Response) {
+			makeInstanceUpdateRequest := func(instanceID string, details map[string]any, queryString string, apiVersion string) (response *http.Response) {
 				withServer(brokerAPI, func(r requester) {
 					path := "/v2/service_instances/" + instanceID + queryString
 
@@ -1221,22 +1221,22 @@ var _ = Describe("Service Broker API", func() {
 
 			BeforeEach(func() {
 				instanceID = uniqueInstanceID()
-				details = map[string]interface{}{
+				details = map[string]any{
 					"service_id": "some-service-id",
 					"plan_id":    "new-plan",
-					"parameters": map[string]interface{}{
+					"parameters": map[string]any{
 						"new-param": "new-param-value",
 					},
-					"previous_values": map[string]interface{}{
+					"previous_values": map[string]any{
 						"service_id":      "service-id",
 						"plan_id":         "old-plan",
 						"organization_id": "org-id",
 						"space_id":        "space-id",
 					},
-					"context": map[string]interface{}{
+					"context": map[string]any{
 						"new-context": "new-context-value",
 					},
-					"maintenance_info": map[string]interface{}{
+					"maintenance_info": map[string]any{
 						"public": map[string]string{
 							"k8s-version": "0.0.1-alpha2",
 						},
@@ -1433,12 +1433,12 @@ var _ = Describe("Service Broker API", func() {
 
 			Context("when the instance exists", func() {
 				var instanceID string
-				var provisionDetails map[string]interface{}
+				var provisionDetails map[string]any
 
 				BeforeEach(func() {
 					instanceID = uniqueInstanceID()
 
-					provisionDetails = map[string]interface{}{
+					provisionDetails = map[string]any{
 						"service_id":        fakeServiceBroker.ServiceID,
 						"plan_id":           "plan-id",
 						"organization_guid": "organization-guid",
@@ -1582,11 +1582,11 @@ var _ = Describe("Service Broker API", func() {
 
 			Context("when instance deprovisioning fails", func() {
 				var instanceID string
-				var provisionDetails map[string]interface{}
+				var provisionDetails map[string]any
 
 				BeforeEach(func() {
 					instanceID = uniqueInstanceID()
-					provisionDetails = map[string]interface{}{
+					provisionDetails = map[string]any{
 						"plan_id":           "plan-id",
 						"organization_guid": "organization-guid",
 						"space_guid":        "space-guid",
@@ -1852,7 +1852,7 @@ var _ = Describe("Service Broker API", func() {
 			return response
 		}
 
-		makeBindingRequestWithSpecificAPIVersion := func(instanceID, bindingID string, details map[string]interface{}, apiVersion string, async bool) (response *http.Response) {
+		makeBindingRequestWithSpecificAPIVersion := func(instanceID, bindingID string, details map[string]any, apiVersion string, async bool) (response *http.Response) {
 			withServer(brokerAPI, func(r requester) {
 				path := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s?accepts_incomplete=%v",
 					instanceID, bindingID, async)
@@ -1879,11 +1879,11 @@ var _ = Describe("Service Broker API", func() {
 			return response
 		}
 
-		makeBindingRequest := func(instanceID, bindingID string, details map[string]interface{}) *http.Response {
+		makeBindingRequest := func(instanceID, bindingID string, details map[string]any) *http.Response {
 			return makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.10", false)
 		}
 
-		makeAsyncBindingRequest := func(instanceID, bindingID string, details map[string]interface{}) *http.Response {
+		makeAsyncBindingRequest := func(instanceID, bindingID string, details map[string]any) *http.Response {
 			return makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, details, "2.14", true)
 		}
 
@@ -1891,17 +1891,17 @@ var _ = Describe("Service Broker API", func() {
 			var (
 				instanceID string
 				bindingID  string
-				details    map[string]interface{}
+				details    map[string]any
 			)
 
 			BeforeEach(func() {
 				instanceID = uniqueInstanceID()
 				bindingID = uniqueBindingID()
-				details = map[string]interface{}{
+				details = map[string]any{
 					"app_guid":   "app_guid",
 					"plan_id":    "plan_id",
 					"service_id": "service_id",
-					"parameters": map[string]interface{}{
+					"parameters": map[string]any{
 						"new-param": "new-param-value",
 					},
 				}
@@ -1967,7 +1967,7 @@ var _ = Describe("Service Broker API", func() {
 							DeviceType:   "shared",
 							Device: brokerapi.SharedDevice{
 								VolumeId:    "some-guid",
-								MountConfig: map[string]interface{}{"key": "value"},
+								MountConfig: map[string]any{"key": "value"},
 							},
 						}}
 					})
@@ -2009,18 +2009,18 @@ var _ = Describe("Service Broker API", func() {
 					)
 
 					BeforeEach(func() {
-						details["parameters"] = map[string]interface{}{
+						details["parameters"] = map[string]any{
 							"string": "some-string",
 							"number": 1,
 							"object": struct{ Name string }{"some-name"},
-							"array":  []interface{}{"a", "b", "c"},
+							"array":  []any{"a", "b", "c"},
 						}
 
-						details["context"] = map[string]interface{}{
+						details["context"] = map[string]any{
 							"platform":      "fake-platform",
 							"serial-number": 12648430,
 							"object":        struct{ Name string }{"parameter"},
-							"array":         []interface{}{"1", "2", "3"},
+							"array":         []any{"1", "2", "3"},
 						}
 
 						rawParams = `{
@@ -2061,7 +2061,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("calls Bind on the service broker with the bind_resource", func() {
 
-						details["bind_resource"] = map[string]interface{}{
+						details["bind_resource"] = map[string]any{
 							"app_guid":             "a-guid",
 							"space_guid":           "a-space-guid",
 							"route":                "route.cf-apps.com",
@@ -2081,7 +2081,7 @@ var _ = Describe("Service Broker API", func() {
 
 					It("calls Bind on the service broker with an empty bind_resource", func() {
 
-						details["bind_resource"] = map[string]interface{}{}
+						details["bind_resource"] = map[string]any{}
 
 						makeBindingRequest(instanceID, bindingID, details)
 						Expect(fakeServiceBroker.BoundBindings[bindingID].BindResource).NotTo(BeNil())
@@ -2094,7 +2094,7 @@ var _ = Describe("Service Broker API", func() {
 
 				When("backup_agent is requested", func() {
 					BeforeEach(func() {
-						details["bind_resource"] = map[string]interface{}{"backup_agent": true}
+						details["bind_resource"] = map[string]any{"backup_agent": true}
 						fakeServiceBroker.BackupAgentURL = "http://backup.example.com"
 					})
 
@@ -2290,7 +2290,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("missing header X-Broker-API-Version", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "", false)
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]any{}, "", false)
 					Expect(response).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine()).To(HaveKeyWithValue("msg", "version-header-check.broker-api-version-invalid"))
@@ -2298,7 +2298,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("has wrong version of API", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{}, "1.14", false)
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]any{}, "1.14", false)
 					Expect(response).To(HaveHTTPStatus(http.StatusPreconditionFailed))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine()).To(HaveKeyWithValue("msg", "version-header-check.broker-api-version-invalid"))
@@ -2306,7 +2306,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("missing service-id", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"plan_id": "123"}, "2.14", false)
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]any{"plan_id": "123"}, "2.14", false)
 					Expect(response).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine()).To(HaveKeyWithValue("msg", "bind.service-id-missing"))
@@ -2314,7 +2314,7 @@ var _ = Describe("Service Broker API", func() {
 				})
 
 				It("missing plan-id", func() {
-					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]interface{}{"service_id": "123"}, "2.14", false)
+					response := makeBindingRequestWithSpecificAPIVersion(instanceID, bindingID, map[string]any{"service_id": "123"}, "2.14", false)
 					Expect(response).To(HaveHTTPStatus(http.StatusBadRequest))
 					Expect(response.Header.Get("X-Broker-API-Request-Identity")).To(Equal(bindingRequestIdentity))
 					Expect(lastLogLine()).To(HaveKeyWithValue("msg", "bind.plan-id-missing"))
@@ -2347,11 +2347,11 @@ var _ = Describe("Service Broker API", func() {
 
 			Context("when the associated instance exists", func() {
 				var instanceID string
-				var provisionDetails map[string]interface{}
+				var provisionDetails map[string]any
 
 				BeforeEach(func() {
 					instanceID = uniqueInstanceID()
-					provisionDetails = map[string]interface{}{
+					provisionDetails = map[string]any{
 						"service_id":        fakeServiceBroker.ServiceID,
 						"plan_id":           "plan-id",
 						"organization_guid": "organization-guid",
@@ -2365,7 +2365,7 @@ var _ = Describe("Service Broker API", func() {
 
 					BeforeEach(func() {
 						bindingID = uniqueBindingID()
-						makeBindingRequest(instanceID, bindingID, map[string]interface{}{})
+						makeBindingRequest(instanceID, bindingID, map[string]any{})
 					})
 
 					It("missing header X-Broker-API-Version", func() {
@@ -2406,7 +2406,7 @@ var _ = Describe("Service Broker API", func() {
 
 					BeforeEach(func() {
 						bindingID = uniqueBindingID()
-						makeBindingRequest(instanceID, bindingID, map[string]interface{}{
+						makeBindingRequest(instanceID, bindingID, map[string]any{
 							"service_id": "service_id", "plan_id": "plan_id",
 						})
 					})
@@ -2715,10 +2715,10 @@ var _ = Describe("Service Broker API", func() {
 	})
 
 	Describe("NewWithOptions()", func() {
-		var provisionDetails map[string]interface{}
+		var provisionDetails map[string]any
 
 		BeforeEach(func() {
-			provisionDetails = map[string]interface{}{
+			provisionDetails = map[string]any{
 				"service_id":        fakeServiceBroker.ServiceID,
 				"plan_id":           "plan-id",
 				"organization_guid": "organization-guid",

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Catalog", func() {
 				metadata := brokerapi.ServicePlanMetadata{
 					Bullets:     []string{"hello", "its me"},
 					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
+					AdditionalMetadata: map[string]any{
 						"foo": "bar",
 						"baz": 1,
 					},
@@ -191,7 +191,7 @@ var _ = Describe("Catalog", func() {
 				metadata := brokerapi.ServicePlanMetadata{
 					Bullets:     []string{"hello", "its me"},
 					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
+					AdditionalMetadata: map[string]any{
 						"foo": "bar",
 						"baz": 1,
 					},
@@ -221,7 +221,7 @@ var _ = Describe("Catalog", func() {
 				metadata := brokerapi.ServicePlanMetadata{
 					Bullets:     []string{"hello", "its me"},
 					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
+					AdditionalMetadata: map[string]any{
 						"foo": make(chan int),
 					},
 				}
@@ -237,7 +237,7 @@ var _ = Describe("Catalog", func() {
 
 				err := json.Unmarshal([]byte(jsonString), &metadata)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]any{"test"}))
 				Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
 			})
 
@@ -281,7 +281,7 @@ var _ = Describe("Catalog", func() {
 			It("encodes the AdditionalMetadata fields in the metadata fields", func() {
 				metadata := brokerapi.ServiceMetadata{
 					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
+					AdditionalMetadata: map[string]any{
 						"foo": "bar",
 						"baz": 1,
 					},
@@ -301,7 +301,7 @@ var _ = Describe("Catalog", func() {
 			It("it can marshal same structure in parallel requests", func() {
 				metadata := brokerapi.ServiceMetadata{
 					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
+					AdditionalMetadata: map[string]any{
 						"foo": "bar",
 						"baz": 1,
 					},
@@ -329,7 +329,7 @@ var _ = Describe("Catalog", func() {
 			It("returns an error when additional metadata is not marshallable", func() {
 				metadata := brokerapi.ServiceMetadata{
 					DisplayName: "name",
-					AdditionalMetadata: map[string]interface{}{
+					AdditionalMetadata: map[string]any{
 						"foo": make(chan int),
 					},
 				}
@@ -345,7 +345,7 @@ var _ = Describe("Catalog", func() {
 
 				err := json.Unmarshal([]byte(jsonString), &metadata)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+				Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]any{"test"}))
 				Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
 			})
 

--- a/domain/apiresponses/failure_responses.go
+++ b/domain/apiresponses/failure_responses.go
@@ -29,9 +29,9 @@ func NewFailureResponse(err error, statusCode int, loggerAction string) error {
 	}
 }
 
-// ErrorResponse returns an interface{} which will be JSON encoded and form the body
+// ErrorResponse returns an any which will be JSON encoded and form the body
 // of the HTTP response
-func (f *FailureResponse) ErrorResponse() interface{} {
+func (f *FailureResponse) ErrorResponse() any {
 	if f.emptyResponse {
 		return EmptyResponse{}
 	}

--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -29,23 +29,23 @@ type CatalogResponse struct {
 }
 
 type ProvisioningResponse struct {
-	DashboardURL  string      `json:"dashboard_url,omitempty"`
-	OperationData string      `json:"operation,omitempty"`
-	Metadata      interface{} `json:"metadata,omitempty"`
+	DashboardURL  string `json:"dashboard_url,omitempty"`
+	OperationData string `json:"operation,omitempty"`
+	Metadata      any    `json:"metadata,omitempty"`
 }
 
 type GetInstanceResponse struct {
-	ServiceID    string      `json:"service_id"`
-	PlanID       string      `json:"plan_id"`
-	DashboardURL string      `json:"dashboard_url,omitempty"`
-	Parameters   interface{} `json:"parameters,omitempty"`
-	Metadata     interface{} `json:"metadata,omitempty"`
+	ServiceID    string `json:"service_id"`
+	PlanID       string `json:"plan_id"`
+	DashboardURL string `json:"dashboard_url,omitempty"`
+	Parameters   any    `json:"parameters,omitempty"`
+	Metadata     any    `json:"metadata,omitempty"`
 }
 
 type UpdateResponse struct {
-	DashboardURL  string      `json:"dashboard_url,omitempty"`
-	OperationData string      `json:"operation,omitempty"`
-	Metadata      interface{} `json:"metadata,omitempty"`
+	DashboardURL  string `json:"dashboard_url,omitempty"`
+	OperationData string `json:"operation,omitempty"`
+	Metadata      any    `json:"metadata,omitempty"`
 }
 
 type DeprovisionResponse struct {
@@ -62,7 +62,7 @@ type AsyncBindResponse struct {
 }
 
 type BindingResponse struct {
-	Credentials     interface{}          `json:"credentials,omitempty"`
+	Credentials     any                  `json:"credentials,omitempty"`
 	SyslogDrainURL  string               `json:"syslog_drain_url,omitempty"`
 	RouteServiceURL string               `json:"route_service_url,omitempty"`
 	VolumeMounts    []domain.VolumeMount `json:"volume_mounts,omitempty"`
@@ -71,7 +71,7 @@ type BindingResponse struct {
 
 type GetBindingResponse struct {
 	BindingResponse
-	Parameters interface{} `json:"parameters,omitempty"`
+	Parameters any `json:"parameters,omitempty"`
 }
 
 type UnbindResponse struct {
@@ -79,7 +79,7 @@ type UnbindResponse struct {
 }
 
 type ExperimentalVolumeMountBindingResponse struct {
-	Credentials     interface{}                      `json:"credentials,omitempty"`
+	Credentials     any                              `json:"credentials,omitempty"`
 	SyslogDrainURL  string                           `json:"syslog_drain_url,omitempty"`
 	RouteServiceURL string                           `json:"route_service_url,omitempty"`
 	VolumeMounts    []domain.ExperimentalVolumeMount `json:"volume_mounts,omitempty"`

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -76,8 +76,8 @@ type VolumeMount struct {
 }
 
 type SharedDevice struct {
-	VolumeId    string                 `json:"volume_id"`
-	MountConfig map[string]interface{} `json:"mount_config"`
+	VolumeId    string         `json:"volume_id"`
+	MountConfig map[string]any `json:"mount_config"`
 }
 
 type ProvisionDetails struct {
@@ -115,10 +115,10 @@ type DeprovisionServiceSpec struct {
 }
 
 type GetInstanceDetailsSpec struct {
-	ServiceID    string      `json:"service_id"`
-	PlanID       string      `json:"plan_id"`
-	DashboardURL string      `json:"dashboard_url"`
-	Parameters   interface{} `json:"parameters"`
+	ServiceID    string `json:"service_id"`
+	PlanID       string `json:"plan_id"`
+	DashboardURL string `json:"dashboard_url"`
+	Parameters   any    `json:"parameters"`
 	Metadata     InstanceMetadata
 }
 
@@ -193,7 +193,7 @@ type Binding struct {
 	IsAsync         bool          `json:"is_async"`
 	AlreadyExists   bool          `json:"already_exists"`
 	OperationData   string        `json:"operation_data"`
-	Credentials     interface{}   `json:"credentials"`
+	Credentials     any           `json:"credentials"`
 	SyslogDrainURL  string        `json:"syslog_drain_url"`
 	RouteServiceURL string        `json:"route_service_url"`
 	BackupAgentURL  string        `json:"backup_agent_url,omitempty"`
@@ -201,11 +201,11 @@ type Binding struct {
 }
 
 type GetBindingSpec struct {
-	Credentials     interface{}
+	Credentials     any
 	SyslogDrainURL  string
 	RouteServiceURL string
 	VolumeMounts    []VolumeMount
-	Parameters      interface{}
+	Parameters      any
 }
 
 func (d ProvisionDetails) GetRawContext() json.RawMessage {

--- a/domain/service_catalog.go
+++ b/domain/service_catalog.go
@@ -52,7 +52,7 @@ type ServiceBindingSchema struct {
 }
 
 type Schema struct {
-	Parameters map[string]interface{} `json:"parameters"`
+	Parameters map[string]any `json:"parameters"`
 }
 
 type RequiredPermission string

--- a/domain/service_metadata.go
+++ b/domain/service_metadata.go
@@ -14,7 +14,7 @@ type ServiceMetadata struct {
 	DocumentationUrl    string `json:"documentationUrl,omitempty"`
 	SupportUrl          string `json:"supportUrl,omitempty"`
 	Shareable           *bool  `json:"shareable,omitempty"`
-	AdditionalMetadata  map[string]interface{}
+	AdditionalMetadata  map[string]any
 }
 
 func (sm ServiceMetadata) MarshalJSON() ([]byte, error) {
@@ -25,7 +25,7 @@ func (sm ServiceMetadata) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("unmarshallable content in AdditionalMetadata: %w", err)
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (sm *ServiceMetadata) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	additionalMetadata := map[string]interface{}{}
+	additionalMetadata := map[string]any{}
 	if err := json.Unmarshal(data, &additionalMetadata); err != nil {
 		return err
 	}

--- a/domain/service_metadata_test.go
+++ b/domain/service_metadata_test.go
@@ -38,7 +38,7 @@ var _ = Describe("ServiceMetadata", func() {
 		It("encodes the AdditionalMetadata fields in the metadata fields", func() {
 			metadata := domain.ServiceMetadata{
 				DisplayName: "name",
-				AdditionalMetadata: map[string]interface{}{
+				AdditionalMetadata: map[string]any{
 					"foo": "bar",
 					"baz": 1,
 				},
@@ -58,7 +58,7 @@ var _ = Describe("ServiceMetadata", func() {
 		It("it can marshal same structure in parallel requests", func() {
 			metadata := domain.ServiceMetadata{
 				DisplayName: "name",
-				AdditionalMetadata: map[string]interface{}{
+				AdditionalMetadata: map[string]any{
 					"foo": "bar",
 					"baz": 1,
 				},
@@ -86,7 +86,7 @@ var _ = Describe("ServiceMetadata", func() {
 		It("returns an error when additional metadata is not marshallable", func() {
 			metadata := domain.ServiceMetadata{
 				DisplayName: "name",
-				AdditionalMetadata: map[string]interface{}{
+				AdditionalMetadata: map[string]any{
 					"foo": make(chan int),
 				},
 			}
@@ -102,7 +102,7 @@ var _ = Describe("ServiceMetadata", func() {
 
 			err := json.Unmarshal([]byte(jsonString), &metadata)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+			Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]any{"test"}))
 			Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
 		})
 

--- a/domain/service_plan_metadata.go
+++ b/domain/service_plan_metadata.go
@@ -11,7 +11,7 @@ type ServicePlanMetadata struct {
 	DisplayName        string            `json:"displayName,omitempty"`
 	Bullets            []string          `json:"bullets,omitempty"`
 	Costs              []ServicePlanCost `json:"costs,omitempty"`
-	AdditionalMetadata map[string]interface{}
+	AdditionalMetadata map[string]any
 }
 
 type ServicePlanCost struct {
@@ -26,7 +26,7 @@ func (spm *ServicePlanMetadata) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	additionalMetadata := map[string]interface{}{}
+	additionalMetadata := map[string]any{}
 	if err := json.Unmarshal(data, &additionalMetadata); err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (spm ServicePlanMetadata) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("unmarshallable content in AdditionalMetadata: %w", err)
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
 	}

--- a/domain/service_plan_metadata_test.go
+++ b/domain/service_plan_metadata_test.go
@@ -27,7 +27,7 @@ var _ = Describe("ServicePlanMetadata", func() {
 			metadata := domain.ServicePlanMetadata{
 				Bullets:     []string{"hello", "its me"},
 				DisplayName: "name",
-				AdditionalMetadata: map[string]interface{}{
+				AdditionalMetadata: map[string]any{
 					"foo": "bar",
 					"baz": 1,
 				},
@@ -49,7 +49,7 @@ var _ = Describe("ServicePlanMetadata", func() {
 			metadata := domain.ServicePlanMetadata{
 				Bullets:     []string{"hello", "its me"},
 				DisplayName: "name",
-				AdditionalMetadata: map[string]interface{}{
+				AdditionalMetadata: map[string]any{
 					"foo": "bar",
 					"baz": 1,
 				},
@@ -79,7 +79,7 @@ var _ = Describe("ServicePlanMetadata", func() {
 			metadata := domain.ServicePlanMetadata{
 				Bullets:     []string{"hello", "its me"},
 				DisplayName: "name",
-				AdditionalMetadata: map[string]interface{}{
+				AdditionalMetadata: map[string]any{
 					"foo": make(chan int),
 				},
 			}
@@ -95,7 +95,7 @@ var _ = Describe("ServicePlanMetadata", func() {
 
 			err := json.Unmarshal([]byte(jsonString), &metadata)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]interface{}{"test"}))
+			Expect(metadata.AdditionalMetadata["foo"]).To(Equal([]any{"test"}))
 			Expect(metadata.AdditionalMetadata["bar"]).To(Equal("Some display name"))
 		})
 

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -113,11 +113,11 @@ func (fakeBroker *FakeServiceBroker) Services(ctx context.Context) ([]brokerapi.
 					Schemas: &brokerapi.ServiceSchemas{
 						Instance: brokerapi.ServiceInstanceSchema{
 							Create: brokerapi.Schema{
-								Parameters: map[string]interface{}{
+								Parameters: map[string]any{
 									"$schema": "http://json-schema.org/draft-04/schema#",
 									"type":    "object",
-									"properties": map[string]interface{}{
-										"billing-account": map[string]interface{}{
+									"properties": map[string]any{
+										"billing-account": map[string]any{
 											"description": "Billing account number used to charge use of shared fake server.",
 											"type":        "string",
 										},
@@ -125,11 +125,11 @@ func (fakeBroker *FakeServiceBroker) Services(ctx context.Context) ([]brokerapi.
 								},
 							},
 							Update: brokerapi.Schema{
-								Parameters: map[string]interface{}{
+								Parameters: map[string]any{
 									"$schema": "http://json-schema.org/draft-04/schema#",
 									"type":    "object",
-									"properties": map[string]interface{}{
-										"billing-account": map[string]interface{}{
+									"properties": map[string]any{
+										"billing-account": map[string]any{
 											"description": "Billing account number used to charge use of shared fake server.",
 											"type":        "string",
 										},
@@ -139,11 +139,11 @@ func (fakeBroker *FakeServiceBroker) Services(ctx context.Context) ([]brokerapi.
 						},
 						Binding: brokerapi.ServiceBindingSchema{
 							Create: brokerapi.Schema{
-								Parameters: map[string]interface{}{
+								Parameters: map[string]any{
 									"$schema": "http://json-schema.org/draft-04/schema#",
 									"type":    "object",
-									"properties": map[string]interface{}{
-										"billing-account": map[string]interface{}{
+									"properties": map[string]any{
+										"billing-account": map[string]any{
 											"description": "Billing account number used to charge use of shared fake server.",
 											"type":        "string",
 										},
@@ -275,7 +275,7 @@ func (fakeBroker *FakeServiceBroker) GetInstance(context context.Context, instan
 		ServiceID:    fakeBroker.ServiceID,
 		PlanID:       fakeBroker.PlanID,
 		DashboardURL: fakeBroker.DashboardURL,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"param1": "value1",
 		},
 	}, fakeBroker.GetInstanceError

--- a/handlers/api_handler.go
+++ b/handlers/api_handler.go
@@ -34,7 +34,7 @@ func NewApiHandler(broker domain.ServiceBroker, logger *slog.Logger) APIHandler 
 	return APIHandler{serviceBroker: broker, logger: blog.New(logger)}
 }
 
-func (h APIHandler) respond(w http.ResponseWriter, status int, requestIdentity string, response interface{}) {
+func (h APIHandler) respond(w http.ResponseWriter, status int, requestIdentity string, response any) {
 	w.Header().Set("Content-Type", "application/json")
 	if requestIdentity != "" {
 		w.Header().Set("X-Broker-API-Request-Identity", requestIdentity)

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -53,7 +53,7 @@ func (h APIHandler) GetInstance(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var metadata interface{}
+	var metadata any
 	if !instanceDetails.Metadata.IsEmpty() {
 		metadata = instanceDetails.Metadata
 	}

--- a/handlers/provision.go
+++ b/handlers/provision.go
@@ -108,7 +108,7 @@ func (h *APIHandler) Provision(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var metadata interface{}
+	var metadata any
 	if !provisionResponse.Metadata.IsEmpty() {
 		metadata = provisionResponse.Metadata
 	}

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -57,7 +57,7 @@ func (h APIHandler) Update(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var metadata interface{}
+	var metadata any
 	if !updateServiceSpec.Metadata.IsEmpty() {
 		metadata = updateServiceSpec.Metadata
 	}


### PR DESCRIPTION
In Go, "any" was introduced alongside generics because the empty interface "interface{}" was considered a bit confusing. They mean the same thing, and code with "any" is a bit easier to understand and looks more modern. Test fakes were not updated as they are generated code.