### PR TITLE
Allow any value type in InstanceMetadata maps

### DIFF
--- a/domain/apiresponses/responses_test.go
+++ b/domain/apiresponses/responses_test.go
@@ -48,8 +48,8 @@ var _ = Describe("Provisioning Response", func() {
 			It("returns it in the JSON", func() {
 				provisioningResponse := apiresponses.ProvisioningResponse{
 					Metadata: domain.InstanceMetadata{
-						Labels:     map[string]string{"key1": "value1"},
-						Attributes: map[string]string{"key1": "value1"},
+						Labels:     map[string]any{"key1": "value1"},
+						Attributes: map[string]any{"key1": "value1"},
 					},
 				}
 				jsonString := `{"metadata":{"labels":{"key1":"value1"}, "attributes":{"key1":"value1"}}}`
@@ -82,8 +82,8 @@ var _ = Describe("Fetching Response", func() {
 					ServiceID: "sID",
 					PlanID:    "pID",
 					Metadata: domain.InstanceMetadata{
-						Labels:     map[string]string{"key1": "value1"},
-						Attributes: map[string]string{"key1": "value1"},
+						Labels:     map[string]any{"key1": "value1"},
+						Attributes: map[string]any{"key1": "value1"},
 					},
 				}
 				jsonString := `{"service_id":"sID", "plan_id":"pID", "metadata":{"labels":{"key1":"value1"}, "attributes":{"key1":"value1"}}}`
@@ -120,8 +120,8 @@ var _ = Describe("Update Response", func() {
 			It("returns it in the JSON", func() {
 				updateResponse := apiresponses.UpdateResponse{
 					Metadata: domain.InstanceMetadata{
-						Labels:     map[string]string{"key1": "value1"},
-						Attributes: map[string]string{"key1": "value1"},
+						Labels:     map[string]any{"key1": "value1"},
+						Attributes: map[string]any{"key1": "value1"},
 					},
 				}
 				jsonString := `{"metadata":{"labels":{"key1":"value1"}, "attributes":{"key1":"value1"}}}`

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -99,8 +99,8 @@ type ProvisionedServiceSpec struct {
 }
 
 type InstanceMetadata struct {
-	Labels     map[string]string `json:"labels,omitempty"`
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Labels     map[string]any `json:"labels,omitempty"`
+	Attributes map[string]any `json:"attributes,omitempty"`
 }
 
 type DeprovisionDetails struct {


### PR DESCRIPTION
Change for InstanceMetadata maps to follow OSB specification: https://github.com/openservicebrokerapi/servicebroker/blob/v2.17/spec.md#service-instance-metadata

To allow key-value pairs, not only key-value string pair