### PR TITLE
fix: adds endpoint to support get-binding response for OSB v2.16

### DIFF
--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -67,12 +67,12 @@ type BindingResponse struct {
 	RouteServiceURL string               `json:"route_service_url,omitempty"`
 	VolumeMounts    []domain.VolumeMount `json:"volume_mounts,omitempty"`
 	BackupAgentURL  string               `json:"backup_agent_url,omitempty"`
+	Endpoints       []domain.Endpoint    `json:"endpoints,omitempty"`
 }
 
 type GetBindingResponse struct {
 	BindingResponse
-	Parameters any               `json:"parameters,omitempty"`
-	Endpoints  []domain.Endpoint `json:"endpoints,omitempty"`
+	Parameters any `json:"parameters,omitempty"`
 }
 
 type UnbindResponse struct {

--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -71,7 +71,8 @@ type BindingResponse struct {
 
 type GetBindingResponse struct {
 	BindingResponse
-	Parameters any `json:"parameters,omitempty"`
+	Parameters any               `json:"parameters,omitempty"`
+	Endpoints  []domain.Endpoint `json:"endpoints,omitempty"`
 }
 
 type UnbindResponse struct {

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -206,6 +206,13 @@ type GetBindingSpec struct {
 	RouteServiceURL string
 	VolumeMounts    []VolumeMount
 	Parameters      any
+	Endpoints       []Endpoint
+}
+
+type Endpoint struct {
+	Host     string   `json:"host"`
+	Ports    []string `json:"ports"`
+	Protocol string   `json:"protocol,omitempty"`
 }
 
 func (d ProvisionDetails) GetRawContext() json.RawMessage {

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -198,6 +198,7 @@ type Binding struct {
 	RouteServiceURL string        `json:"route_service_url"`
 	BackupAgentURL  string        `json:"backup_agent_url,omitempty"`
 	VolumeMounts    []VolumeMount `json:"volume_mounts"`
+	Endpoints       []Endpoint    `json:"endpoints,omitempty"`
 }
 
 type GetBindingSpec struct {

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -88,6 +88,7 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 			RouteServiceURL: binding.RouteServiceURL,
 			VolumeMounts:    binding.VolumeMounts,
 			BackupAgentURL:  binding.BackupAgentURL,
+			Endpoints:       binding.Endpoints,
 		})
 		return
 	}
@@ -138,5 +139,6 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 		RouteServiceURL: binding.RouteServiceURL,
 		VolumeMounts:    binding.VolumeMounts,
 		BackupAgentURL:  binding.BackupAgentURL,
+		Endpoints:       binding.Endpoints,
 	})
 }

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -59,8 +59,8 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 			SyslogDrainURL:  binding.SyslogDrainURL,
 			RouteServiceURL: binding.RouteServiceURL,
 			VolumeMounts:    binding.VolumeMounts,
+			Endpoints:       binding.Endpoints,
 		},
 		Parameters: binding.Parameters,
-		Endpoints:  binding.Endpoints,
 	})
 }

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -61,5 +61,6 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 			VolumeMounts:    binding.VolumeMounts,
 		},
 		Parameters: binding.Parameters,
+		Endpoints: binding.Endpoints,
 	})
 }

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -61,6 +61,6 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 			VolumeMounts:    binding.VolumeMounts,
 		},
 		Parameters: binding.Parameters,
-		Endpoints: binding.Endpoints,
+		Endpoints:  binding.Endpoints,
 	})
 }


### PR DESCRIPTION
The [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md) defines an endpoint object in the [GET Binding Response](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#binding) that is not defined in the brokerapi response. This pull request adds an endpoint struct and updates the GetBindingReponse and GetBindingSpec to properly support the endpoints object.