### PR TITLE
fix: Add expiration date and time for bindings

### DIFF
--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -62,12 +62,13 @@ type AsyncBindResponse struct {
 }
 
 type BindingResponse struct {
-	Credentials     any                  `json:"credentials,omitempty"`
-	SyslogDrainURL  string               `json:"syslog_drain_url,omitempty"`
-	RouteServiceURL string               `json:"route_service_url,omitempty"`
-	VolumeMounts    []domain.VolumeMount `json:"volume_mounts,omitempty"`
-	BackupAgentURL  string               `json:"backup_agent_url,omitempty"`
-	Endpoints       []domain.Endpoint    `json:"endpoints,omitempty"`
+	Credentials     any                    `json:"credentials,omitempty"`
+	SyslogDrainURL  string                 `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string                 `json:"route_service_url,omitempty"`
+	VolumeMounts    []domain.VolumeMount   `json:"volume_mounts,omitempty"`
+	BackupAgentURL  string                 `json:"backup_agent_url,omitempty"`
+	Endpoints       []domain.Endpoint      `json:"endpoints,omitempty"`
+	Metadata        domain.BindingMetadata `json:"metadata,omitempty"`
 }
 
 type GetBindingResponse struct {

--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -62,13 +62,13 @@ type AsyncBindResponse struct {
 }
 
 type BindingResponse struct {
-	Credentials     any                    `json:"credentials,omitempty"`
-	SyslogDrainURL  string                 `json:"syslog_drain_url,omitempty"`
-	RouteServiceURL string                 `json:"route_service_url,omitempty"`
-	VolumeMounts    []domain.VolumeMount   `json:"volume_mounts,omitempty"`
-	BackupAgentURL  string                 `json:"backup_agent_url,omitempty"`
-	Endpoints       []domain.Endpoint      `json:"endpoints,omitempty"`
-	Metadata        domain.BindingMetadata `json:"metadata,omitempty"`
+	Credentials     any                  `json:"credentials,omitempty"`
+	SyslogDrainURL  string               `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string               `json:"route_service_url,omitempty"`
+	VolumeMounts    []domain.VolumeMount `json:"volume_mounts,omitempty"`
+	BackupAgentURL  string               `json:"backup_agent_url,omitempty"`
+	Endpoints       []domain.Endpoint    `json:"endpoints,omitempty"`
+	Metadata        any                  `json:"metadata,omitempty"`
 }
 
 type GetBindingResponse struct {

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -190,15 +190,20 @@ type UnbindSpec struct {
 }
 
 type Binding struct {
-	IsAsync         bool          `json:"is_async"`
-	AlreadyExists   bool          `json:"already_exists"`
-	OperationData   string        `json:"operation_data"`
-	Credentials     any           `json:"credentials"`
-	SyslogDrainURL  string        `json:"syslog_drain_url"`
-	RouteServiceURL string        `json:"route_service_url"`
-	BackupAgentURL  string        `json:"backup_agent_url,omitempty"`
-	VolumeMounts    []VolumeMount `json:"volume_mounts"`
-	Endpoints       []Endpoint    `json:"endpoints,omitempty"`
+	IsAsync         bool            `json:"is_async"`
+	AlreadyExists   bool            `json:"already_exists"`
+	OperationData   string          `json:"operation_data"`
+	Credentials     any             `json:"credentials"`
+	SyslogDrainURL  string          `json:"syslog_drain_url"`
+	RouteServiceURL string          `json:"route_service_url"`
+	BackupAgentURL  string          `json:"backup_agent_url,omitempty"`
+	VolumeMounts    []VolumeMount   `json:"volume_mounts"`
+	Endpoints       []Endpoint      `json:"endpoints,omitempty"`
+	Metadata        BindingMetadata `json:"metadata,omitempty"`
+}
+
+type BindingMetadata struct {
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 type GetBindingSpec struct {
@@ -208,6 +213,7 @@ type GetBindingSpec struct {
 	VolumeMounts    []VolumeMount
 	Parameters      any
 	Endpoints       []Endpoint
+	Metadata        BindingMetadata
 }
 
 type Endpoint struct {

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -243,6 +243,10 @@ func (m InstanceMetadata) IsEmpty() bool {
 	return len(m.Attributes) == 0 && len(m.Labels) == 0
 }
 
+func (m BindingMetadata) IsEmpty() bool {
+	return len(m.ExpiresAt) == 0 && len(m.RenewBefore) == 0
+}
+
 func (d UpdateDetails) GetRawContext() json.RawMessage {
 	return d.RawContext
 }

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -203,7 +203,8 @@ type Binding struct {
 }
 
 type BindingMetadata struct {
-	ExpiresAt string `json:"expires_at,omitempty"`
+	ExpiresAt   string `json:"expires_at,omitempty"`
+	RenewBefore string `json:"renew_before,omitempty"`
 }
 
 type GetBindingSpec struct {

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -81,6 +81,11 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata any
+	if !binding.Metadata.IsEmpty() {
+		metadata = binding.Metadata
+	}
+
 	if binding.AlreadyExists {
 		h.respond(w, http.StatusOK, requestId, apiresponses.BindingResponse{
 			Credentials:     binding.Credentials,
@@ -89,7 +94,7 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 			VolumeMounts:    binding.VolumeMounts,
 			BackupAgentURL:  binding.BackupAgentURL,
 			Endpoints:       binding.Endpoints,
-			Metadata:        binding.Metadata,
+			Metadata:        metadata,
 		})
 		return
 	}
@@ -141,6 +146,6 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 		VolumeMounts:    binding.VolumeMounts,
 		BackupAgentURL:  binding.BackupAgentURL,
 		Endpoints:       binding.Endpoints,
-		Metadata:        binding.Metadata,
+		Metadata:        metadata,
 	})
 }

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -89,6 +89,7 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 			VolumeMounts:    binding.VolumeMounts,
 			BackupAgentURL:  binding.BackupAgentURL,
 			Endpoints:       binding.Endpoints,
+			Metadata:        binding.Metadata,
 		})
 		return
 	}
@@ -140,5 +141,6 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 		VolumeMounts:    binding.VolumeMounts,
 		BackupAgentURL:  binding.BackupAgentURL,
 		Endpoints:       binding.Endpoints,
+		Metadata:        binding.Metadata,
 	})
 }

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -60,6 +60,7 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 			RouteServiceURL: binding.RouteServiceURL,
 			VolumeMounts:    binding.VolumeMounts,
 			Endpoints:       binding.Endpoints,
+			Metadata:        binding.Metadata,
 		},
 		Parameters: binding.Parameters,
 	})

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -53,6 +53,11 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata any
+	if !binding.Metadata.IsEmpty() {
+		metadata = binding.Metadata
+	}
+
 	h.respond(w, http.StatusOK, requestId, apiresponses.GetBindingResponse{
 		BindingResponse: apiresponses.BindingResponse{
 			Credentials:     binding.Credentials,
@@ -60,7 +65,7 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 			RouteServiceURL: binding.RouteServiceURL,
 			VolumeMounts:    binding.VolumeMounts,
 			Endpoints:       binding.Endpoints,
-			Metadata:        binding.Metadata,
+			Metadata:        metadata,
 		},
 		Parameters: binding.Parameters,
 	})


### PR DESCRIPTION
According to OSB API Spec, the Binding Object contains a Metadata Object with `expires_at` and `renew_before` which are missing in the current implementation. `expires_at` was introduces in OSB API [2.16](https://github.com/openservicebrokerapi/servicebroker/blob/master/release-notes.md#v216) and `renew_before` in [2.17](https://github.com/openservicebrokerapi/servicebroker/blob/master/release-notes.md#v217).