### PR TITLE
test: prevent upgrade of Go version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: ${{ matrix.version }}
     - uses: actions/checkout@v4
-    - run: make test
+    - run: GOTOOLCHAIN=local make test
   call-dependabot-pr-workflow:
     needs: test
     if: ${{ success() && github.actor == 'dependabot[bot]' }}


### PR DESCRIPTION
We deliberately test against a matrix of Go versions, but Go toolchain changes mean that the version of Go is being upgraded on the fly, so for example the Go 1.21 test actually uses Go 1.23. This is confusing and not the desired behavior.