### PR TITLE
chore: Drop support for go 1.22

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'stable', 'oldstable', '1.22' ]
+        version: [ 'stable', 'oldstable' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'stable', 'oldstable' ]
+        version: [ '1.24', '1.23' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal-cf/brokerapi/v12
 
-go 1.22.1
+go 1.23
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Go 1.22 is no longer in active support.

Removed use of stable and oldstable alias due to oldstable resolving to an out of support version