### PR TITLE
feat: handlers use errors.As to find wrapped FailureResponse errors

### DIFF
--- a/handlers/catalog.go
+++ b/handlers/catalog.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -17,10 +18,11 @@ func (h APIHandler) Catalog(w http.ResponseWriter, req *http.Request) {
 
 	services, err := h.serviceBroker.Services(req.Context())
 	if err != nil {
-		switch err := err.(type) {
-		case *apiresponses.FailureResponse:
-			logger.Error(err.LoggerAction(), err)
-			h.respond(w, err.ValidatedStatusCode(slog.New(logger)), requestId, err.ErrorResponse())
+		var apiErr *apiresponses.FailureResponse
+		switch {
+		case errors.As(err, &apiErr):
+			logger.Error(apiErr.LoggerAction(), err)
+			h.respond(w, apiErr.ValidatedStatusCode(slog.New(logger)), requestId, apiErr.ErrorResponse())
 		default:
 			logger.Error(unknownErrorKey, err)
 			h.respond(w, http.StatusInternalServerError, requestId, apiresponses.ErrorResponse{

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -39,10 +39,11 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 
 	binding, err := h.serviceBroker.GetBinding(req.Context(), instanceID, bindingID, details)
 	if err != nil {
-		switch err := err.(type) {
-		case *apiresponses.FailureResponse:
-			logger.Error(err.LoggerAction(), err)
-			h.respond(w, err.ValidatedStatusCode(slog.New(logger)), requestId, err.ErrorResponse())
+		var apiErr *apiresponses.FailureResponse
+		switch {
+		case errors.As(err, &apiErr):
+			logger.Error(apiErr.LoggerAction(), err)
+			h.respond(w, apiErr.ValidatedStatusCode(slog.New(logger)), requestId, apiErr.ErrorResponse())
 		default:
 			logger.Error(unknownErrorKey, err)
 			h.respond(w, http.StatusInternalServerError, requestId, apiresponses.ErrorResponse{

--- a/handlers/get_instance.go
+++ b/handlers/get_instance.go
@@ -39,10 +39,11 @@ func (h APIHandler) GetInstance(w http.ResponseWriter, req *http.Request) {
 
 	instanceDetails, err := h.serviceBroker.GetInstance(req.Context(), instanceID, details)
 	if err != nil {
-		switch err := err.(type) {
-		case *apiresponses.FailureResponse:
-			logger.Error(err.LoggerAction(), err)
-			h.respond(w, err.ValidatedStatusCode(slog.New(logger)), requestId, err.ErrorResponse())
+		var apiErr *apiresponses.FailureResponse
+		switch {
+		case errors.As(err, &apiErr):
+			logger.Error(apiErr.LoggerAction(), err)
+			h.respond(w, apiErr.ValidatedStatusCode(slog.New(logger)), requestId, apiErr.ErrorResponse())
 		default:
 			logger.Error(unknownErrorKey, err)
 			h.respond(w, http.StatusInternalServerError, requestId, apiresponses.ErrorResponse{

--- a/handlers/last_binding_operation.go
+++ b/handlers/last_binding_operation.go
@@ -41,10 +41,11 @@ func (h APIHandler) LastBindingOperation(w http.ResponseWriter, req *http.Reques
 
 	lastOperation, err := h.serviceBroker.LastBindingOperation(req.Context(), instanceID, bindingID, pollDetails)
 	if err != nil {
-		switch err := err.(type) {
-		case *apiresponses.FailureResponse:
-			logger.Error(err.LoggerAction(), err)
-			h.respond(w, err.ValidatedStatusCode(slog.New(logger)), requestId, err.ErrorResponse())
+		var apiErr *apiresponses.FailureResponse
+		switch {
+		case errors.As(err, &apiErr):
+			logger.Error(apiErr.LoggerAction(), err)
+			h.respond(w, apiErr.ValidatedStatusCode(slog.New(logger)), requestId, apiErr.ErrorResponse())
 		default:
 			logger.Error(unknownErrorKey, err)
 			h.respond(w, http.StatusInternalServerError, requestId, apiresponses.ErrorResponse{

--- a/handlers/unbind.go
+++ b/handlers/unbind.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -45,10 +46,11 @@ func (h APIHandler) Unbind(w http.ResponseWriter, req *http.Request) {
 	asyncAllowed := req.FormValue("accepts_incomplete") == "true"
 	unbindResponse, err := h.serviceBroker.Unbind(req.Context(), instanceID, bindingID, details, asyncAllowed)
 	if err != nil {
-		switch err := err.(type) {
-		case *apiresponses.FailureResponse:
-			logger.Error(err.LoggerAction(), err)
-			h.respond(w, err.ValidatedStatusCode(slog.New(logger)), requestId, err.ErrorResponse())
+		var apiErr *apiresponses.FailureResponse
+		switch {
+		case errors.As(err, &apiErr):
+			logger.Error(apiErr.LoggerAction(), err)
+			h.respond(w, apiErr.ValidatedStatusCode(slog.New(logger)), requestId, apiErr.ErrorResponse())
 		default:
 			logger.Error(unknownErrorKey, err)
 			h.respond(w, http.StatusInternalServerError, requestId, apiresponses.ErrorResponse{


### PR DESCRIPTION
### Description
- Update the handlers to use wrapped FailureResponse errors. This makes it more useful when wrapping errors is a common practise in the broker.
- The logging still uses the top level error to generate the log message. This allows to having a wrapped error for the response to define a friendly user facing error message or hide implementation details in error messages. The top level error with all information gets logged as usual.