### PR TITLE
chore: remove go 1.23 tests and float go versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.25', '1.24' ]
+        version: [ 'oldstable', 'stable' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
1.23 is out of support now.